### PR TITLE
Refactor : Entity equels()/hashCode() Annotation으로 변경

### DIFF
--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/model/Comment.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/model/Comment.java
@@ -1,22 +1,18 @@
 package org.fastcampus.oruryapi.domain.comment.db.model;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.fastcampus.oruryapi.domain.post.db.model.Post;
 import org.fastcampus.oruryapi.domain.user.db.model.User;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.util.Objects;
-
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "comment")
 public class Comment extends AuditingField {
@@ -48,18 +44,5 @@ public class Comment extends AuditingField {
 
     public static Comment of(String content, Long parentId, Post post, User user) {
         return new Comment(content, parentId, post, user);
-    }
-
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Comment comment)) return false;
-        return Objects.equals(id, comment.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/model/CommentLike.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/model/CommentLike.java
@@ -3,19 +3,15 @@ package org.fastcampus.oruryapi.domain.comment.db.model;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.util.Objects;
 
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"commentLikePK"})
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "comment_like")
 public class CommentLike {
@@ -28,17 +24,5 @@ public class CommentLike {
 
     public static CommentLike of(CommentLikePK commentLikePK) {
         return new CommentLike(commentLikePK);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof CommentLike commentLike)) return false;
-        return Objects.equals(commentLikePK, commentLike.commentLikePK);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(commentLikePK);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/Post.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/Post.java
@@ -1,21 +1,17 @@
 package org.fastcampus.oruryapi.domain.post.db.model;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.fastcampus.oruryapi.domain.user.db.model.User;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.util.Objects;
-
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "post")
 public class Post extends AuditingField {
@@ -53,17 +49,5 @@ public class Post extends AuditingField {
 
     public static Post of(String title, String content, String images, int category, User user) {
         return new Post(title, content, images, category, user);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Post post)) return false;
-        return Objects.equals(id, post.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLike.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLike.java
@@ -3,19 +3,15 @@ package org.fastcampus.oruryapi.domain.post.db.model;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.util.Objects;
 
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"postLikePK"})
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "post_like")
 public class PostLike {
@@ -28,17 +24,5 @@ public class PostLike {
 
     public static PostLike of(PostLikePK postLikePK) {
         return new PostLike(postLikePK);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof PostLike postLike)) return false;
-        return Objects.equals(postLikePK, postLike.postLikePK);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(postLikePK);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/converter/dto/UserDto.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/converter/dto/UserDto.java
@@ -3,6 +3,7 @@ package org.fastcampus.oruryapi.domain.user.converter.dto;
 import org.fastcampus.oruryapi.domain.user.db.model.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * DTO for {@link User}
@@ -11,47 +12,37 @@ public record UserDto(
         Long id,
         String email,
         String nickname,
-        int signupType,
+        String password,
+        int signUpType,
         int gender,
         LocalDate birthday,
-        String profileImage
+        String profileImage,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
     public static UserDto of(
             Long id,
             String email,
             String nickname,
-            int signupType,
+            String password,
+            int signUpType,
             int gender,
             LocalDate birthday,
-            String profileImage
+            String profileImage,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
     ) {
         return new UserDto(
                 id,
                 email,
                 nickname,
-                signupType,
+                password,
+                signUpType,
                 gender,
                 birthday,
-                profileImage
-        );
-    }
-
-    public static UserDto of(
-            String email,
-            String nickname,
-            int signupType,
-            int gender,
-            LocalDate birthday,
-            String profileImage
-    ) {
-        return new UserDto(
-                null,
-                email,
-                nickname,
-                signupType,
-                gender,
-                birthday,
-                profileImage
+                profileImage,
+                createdAt,
+                updatedAt
         );
     }
 
@@ -60,10 +51,13 @@ public record UserDto(
                 entity.getId(),
                 entity.getEmail(),
                 entity.getNickname(),
-                entity.getSignupType(),
+                entity.getPassword(),
+                entity.getSignUpType(),
                 entity.getGender(),
                 entity.getBirthday(),
-                entity.getProfileImage()
+                entity.getProfileImage(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
         );
     }
 
@@ -71,7 +65,8 @@ public record UserDto(
         return User.of(
                 email,
                 nickname,
-                signupType,
+                password,
+                signUpType,
                 gender,
                 birthday,
                 profileImage

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/db/model/User.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/db/model/User.java
@@ -1,21 +1,18 @@
 package org.fastcampus.oruryapi.domain.user.db.model;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "user")
 public class User extends AuditingField {
@@ -45,7 +42,7 @@ public class User extends AuditingField {
     @Column(name = "profile_image")
     private String profileImage;
 
-    private User(String email, String nickname, String Password, int signUpType, int gender, LocalDate birthday, String profileImage) {
+    private User(String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
@@ -57,17 +54,5 @@ public class User extends AuditingField {
 
     public static User of(String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage) {
         return new User(email, nickname, password, signUpType, gender, birthday, profileImage);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof User user)) return false;
-        return Objects.equals(id, user.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
     }
 }


### PR DESCRIPTION
## 개요
Entity에서 작성됐던 equels(), hashCode() 메서드를 @EqualsAndHashCode 어노테이션으로 변경했습니다.
of = {"id"}를 통해 id에서만 equels(), hashCode() 메서드를 사용하고,
callSuper = false를 통해 AuditingField의 createdAt, updatedAt을 해당 메서드에서 배제하도록 했습니다.

@EqualsAndHashCode 어노테이션에 대한 정보는 아래 포스트를 읽어보시면 이해가 잘 될 것 같습니다~!
https://junhyunny.github.io/information/java/equals-and-hashcode/

closed #37

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
