### PR TITLE
Feature/#28 post(게시글) crud

### DIFF
--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/repository/CommentRepository.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/comment/db/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package org.fastcampus.oruryapi.domain.comment.db.repository;
+
+import org.fastcampus.oruryapi.domain.comment.db.model.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByPostId(Long postId);
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostController.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostController.java
@@ -2,12 +2,85 @@ package org.fastcampus.oruryapi.domain.post.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.fastcampus.oruryapi.base.converter.ApiResponse;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostCreateRequest;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostUpdateRequest;
+import org.fastcampus.oruryapi.domain.post.converter.response.PostResponse;
+import org.fastcampus.oruryapi.domain.post.converter.response.PostsWithCursorResponse;
+import org.fastcampus.oruryapi.domain.post.service.PostService;
+import org.fastcampus.oruryapi.global.message.info.InfoMessage;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping
 @RestController
 public class PostController {
+    private final PostService postService;
+
+    @PostMapping("/post")
+    public ApiResponse<Object> createPost(@RequestBody PostCreateRequest request) {
+        postService.createPost(request);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POST_CREATED.getMessage())
+                .build();
+    }
+
+    @GetMapping("/post/{postId}")
+    public ApiResponse<PostResponse> getPostById(@PathVariable Long postId) {
+        postService.addViewCount(postId);
+        PostResponse response = postService.getPostById(postId);
+
+        return ApiResponse.<PostResponse>builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POST_READ.getMessage())
+                .data(response)
+                .build();
+    }
+
+    @GetMapping("/posts/{category}")
+    public ApiResponse<PostsWithCursorResponse> getPostsByCategory(@PathVariable int category, @RequestParam Long cursor) {
+        PostsWithCursorResponse responses = postService.getPostsByCategory(category, cursor, PageRequest.of(0, 10));
+
+        return ApiResponse.<PostsWithCursorResponse>builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POSTS_READ.getMessage())
+                .data(responses)
+                .build();
+    }
+
+    @GetMapping("/posts")
+    public ApiResponse<PostsWithCursorResponse> getPostsBySearchWord(@RequestParam String searchWord, Long cursor) {
+        PostsWithCursorResponse responses = postService.getPostsBySearchWord(searchWord, cursor, PageRequest.of(0, 10));
+
+        return ApiResponse.<PostsWithCursorResponse>builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POSTS_READ.getMessage())
+                .data(responses)
+                .build();
+    }
+
+    @PatchMapping("/post")
+    public ApiResponse<Object> updatePost(@RequestBody PostUpdateRequest request) {
+        postService.updatePost(request);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POST_UPDATED.getMessage())
+                .build();
+    }
+
+    @DeleteMapping("/post/{postId}")
+    public ApiResponse<Object> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.COMMENT_DELETED.getMessage())
+                .build();
+    }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostController.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package org.fastcampus.oruryapi.domain.post.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryapi.base.converter.ApiResponse;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
     private final PostService postService;
 
+    @Operation(summary = "게시글 생성", description = "게시글 정보를 받아, 게시글을 생성한다.")
     @PostMapping("/post")
     public ApiResponse<Object> createPost(@RequestBody PostCreateRequest request) {
         postService.createPost(request);
@@ -30,6 +32,7 @@ public class PostController {
                 .build();
     }
 
+    @Operation(summary = "게시글 상세 조회", description = "게시글 id를 받아, 게시글 상세 정보를 돌려준다.")
     @GetMapping("/post/{postId}")
     public ApiResponse<PostResponse> getPostById(@PathVariable Long postId) {
         postService.addViewCount(postId);
@@ -42,6 +45,7 @@ public class PostController {
                 .build();
     }
 
+    @Operation(summary = "카테고리별 게시글 목록 조회", description = "카테고리(1: 자유게시판, 2: Q&A게시판)와 cursor값을 받아, '카테고리와 cursor값에 따른 다음 게시글 목록'과 'cursor값(목록의 마지막 게시글 id / 조회된 게시글 없다면 -1L)'을 돌려준다.")
     @GetMapping("/posts/{category}")
     public ApiResponse<PostsWithCursorResponse> getPostsByCategory(@PathVariable int category, @RequestParam Long cursor) {
         PostsWithCursorResponse responses = postService.getPostsByCategory(category, cursor, PageRequest.of(0, 10));
@@ -53,6 +57,7 @@ public class PostController {
                 .build();
     }
 
+    @Operation(summary = "검색어에 따른 게시글 목록 조회", description = "검색어와 cursor값을 받아, '검색어와 cursor값에 따른 다음 게시글 목록'과 'cursor값(목록의 마지막 게시글 id / 조회된 게시글 없다면 -1L)'을 돌려준다.")
     @GetMapping("/posts")
     public ApiResponse<PostsWithCursorResponse> getPostsBySearchWord(@RequestParam String searchWord, Long cursor) {
         PostsWithCursorResponse responses = postService.getPostsBySearchWord(searchWord, cursor, PageRequest.of(0, 10));
@@ -64,6 +69,7 @@ public class PostController {
                 .build();
     }
 
+    @Operation(summary = "게시글 수정", description = "게시글 정보를 받아, 게시글을 수정한다.")
     @PatchMapping("/post")
     public ApiResponse<Object> updatePost(@RequestBody PostUpdateRequest request) {
         postService.updatePost(request);
@@ -74,6 +80,7 @@ public class PostController {
                 .build();
     }
 
+    @Operation(summary = "게시글 삭제", description = "게시글 id를 받아, 게시글을 삭제한다.")
     @DeleteMapping("/post/{postId}")
     public ApiResponse<Object> deletePost(@PathVariable Long postId) {
         postService.deletePost(postId);

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostLikeController.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostLikeController.java
@@ -1,0 +1,38 @@
+package org.fastcampus.oruryapi.domain.post.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.base.converter.ApiResponse;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostLikeRequest;
+import org.fastcampus.oruryapi.domain.post.service.PostLikeService;
+import org.fastcampus.oruryapi.global.message.info.InfoMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping
+@RestController
+public class PostLikeController {
+    private final PostLikeService postLikeService;
+
+    @PutMapping("/post/like")
+    public ApiResponse<Object> createPostLike(@RequestBody PostLikeRequest postLikeRequest) {
+        postLikeService.createPostLike(postLikeRequest);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POST_LIKE_CREATED.getMessage())
+                .build();
+    }
+
+    @DeleteMapping("/post/like")
+    public ApiResponse<Object> deletePostLike(@RequestBody PostLikeRequest postLikeRequest) {
+        postLikeService.deletePostLike(postLikeRequest);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(InfoMessage.POST_LIKE_DELETED.getMessage())
+                .build();
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostLikeController.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/controller/PostLikeController.java
@@ -1,5 +1,6 @@
 package org.fastcampus.oruryapi.domain.post.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryapi.base.converter.ApiResponse;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostLikeController {
     private final PostLikeService postLikeService;
 
+    @Operation(summary = "게시글 좋아요 생성", description = "유저 id와 게시글 id를 받아, 게시글 좋아요를 생성한다.")
     @PutMapping("/post/like")
     public ApiResponse<Object> createPostLike(@RequestBody PostLikeRequest postLikeRequest) {
         postLikeService.createPostLike(postLikeRequest);
@@ -26,6 +28,7 @@ public class PostLikeController {
                 .build();
     }
 
+    @Operation(summary = "게시글 좋아요 삭제", description = "유저 id와 게시글 id를 받아, 게시글 좋아요를 삭제한다.")
     @DeleteMapping("/post/like")
     public ApiResponse<Object> deletePostLike(@RequestBody PostLikeRequest postLikeRequest) {
         postLikeService.deletePostLike(postLikeRequest);

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/dto/PostDto.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/dto/PostDto.java
@@ -59,11 +59,15 @@ public record PostDto(
 
     public Post toEntity() {
         return Post.of(
+                id,
                 title,
                 content,
+                viewCount,
                 images,
                 category,
-                userDto.toEntity()
+                userDto.toEntity(),
+                createdAt,
+                updatedAt
         );
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/dto/PostLikePKDto.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/dto/PostLikePKDto.java
@@ -1,0 +1,31 @@
+package org.fastcampus.oruryapi.domain.post.converter.dto;
+
+import org.fastcampus.oruryapi.domain.post.db.model.PostLikePK;
+
+public record PostLikePKDto(
+        Long userId,
+        Long postId
+) {
+    private static PostLikePKDto of(
+            Long userId,
+            Long postId
+    ) {
+        return new PostLikePKDto(
+                userId,
+                postId
+        );
+    }
+
+    public static PostLikePKDto from(PostLikePK entity) {
+        return PostLikePKDto.of(
+                entity.getUserId(),
+                entity.getPostId()
+        );
+    }
+
+    public PostLikePK toEntity() {
+        return PostLikePK.of(
+                userId, postId
+        );
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostCreateRequest.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostCreateRequest.java
@@ -1,0 +1,32 @@
+package org.fastcampus.oruryapi.domain.post.converter.request;
+
+import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+import org.fastcampus.oruryapi.domain.user.converter.dto.UserDto;
+
+@Slf4j
+public record PostCreateRequest(
+        String title,
+        String content,
+        String images,
+        int category,
+        Long userId
+) {
+    public static PostCreateRequest of(String title, String content, String images, int category, Long userId) {
+        return new PostCreateRequest(title, content, images, category, userId);
+    }
+
+    public PostDto toDto(UserDto userDto) {
+        return PostDto.of(
+                null,
+                title,
+                content,
+                0,
+                images,
+                category,
+                userDto,
+                null,
+                null
+        );
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostLikeRequest.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostLikeRequest.java
@@ -1,0 +1,19 @@
+package org.fastcampus.oruryapi.domain.post.converter.request;
+
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostLikePKDto;
+import org.fastcampus.oruryapi.domain.post.db.model.PostLikePK;
+import org.fastcampus.oruryapi.domain.user.converter.dto.UserDto;
+
+public record PostLikeRequest(
+        Long userId,
+        Long postId
+) {
+    public static PostLikeRequest of(Long userId, Long postId) {
+        return new PostLikeRequest(userId, postId);
+    }
+
+    public PostLikePKDto toDto(UserDto userDto, PostDto postDto) {
+        return PostLikePKDto.from(PostLikePK.of(userDto.id(), postDto.id()));
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostUpdateRequest.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/request/PostUpdateRequest.java
@@ -1,0 +1,33 @@
+package org.fastcampus.oruryapi.domain.post.converter.request;
+
+import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+import org.fastcampus.oruryapi.domain.user.converter.dto.UserDto;
+
+@Slf4j
+public record PostUpdateRequest(
+        Long id,
+        String title,
+        String content,
+        String images,
+        int category,
+        Long userId
+) {
+    public static PostUpdateRequest of(Long id, String title, String content, String images, int category, Long userId) {
+        return new PostUpdateRequest(id, title, content, images, category, userId);
+    }
+
+    public PostDto toDto(PostDto postDto, UserDto userDto) {
+        return PostDto.of(
+                postDto.id(),
+                    title,
+                    content,
+                    postDto.viewCount(),
+                    images,
+                    category,
+                    userDto,
+                    postDto.createdAt(),
+                    null
+        );
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostResponse.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostResponse.java
@@ -1,0 +1,41 @@
+package org.fastcampus.oruryapi.domain.post.converter.response;
+
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        int viewCount,
+        String images,
+        int category,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        Long userId,
+        String userNickname,
+        String userProfileImage,
+        int likeCount,
+        int commentCount,
+        boolean isLike
+) {
+    public static PostResponse of(PostDto postDto, int likeCount, int commentCount, boolean isLike) {
+        return new PostResponse(
+                postDto.id(),
+                postDto.title(),
+                postDto.content(),
+                postDto.viewCount(),
+                postDto.images(),
+                postDto.category(),
+                postDto.createdAt(),
+                postDto.updatedAt(),
+                postDto.userDto().id(),
+                postDto.userDto().nickname(),
+                postDto.userDto().profileImage(),
+                likeCount,
+                commentCount,
+                isLike
+        );
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostsResponse.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostsResponse.java
@@ -1,0 +1,40 @@
+package org.fastcampus.oruryapi.domain.post.converter.response;
+
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+
+import java.time.LocalDateTime;
+
+public record PostsResponse(
+        Long id,
+        String title,
+        String content,
+        int viewCount,
+        String thumbnailImage,
+        int category,
+        Long userId,
+        String userNickname,
+        String userProfileImage,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        int likeCount,
+        int commentCount
+) {
+    public static PostsResponse of(PostDto postDto, int likeCount, int commentCount) {
+
+        return new PostsResponse(
+                postDto.id(),
+                postDto.title(),
+                postDto.content(),
+                postDto.viewCount(),
+                postDto.images(),
+                postDto.category(),
+                postDto.userDto().id(),
+                postDto.userDto().nickname(),
+                postDto.userDto().profileImage(),
+                postDto.createdAt(),
+                postDto.updatedAt(),
+                likeCount,
+                commentCount
+        );
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostsWithCursorResponse.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/PostsWithCursorResponse.java
@@ -1,0 +1,17 @@
+package org.fastcampus.oruryapi.domain.post.converter.response;
+
+import java.util.List;
+
+public record PostsWithCursorResponse(
+        List<PostsResponse> posts,
+        Long cursor
+) {
+    public static PostsWithCursorResponse of(List<PostsResponse> posts) {
+
+        Long cursor = (posts.isEmpty())
+                ? -1L // -1L
+                : posts.get(posts.size() - 1).id();
+
+        return new PostsWithCursorResponse(posts, cursor);
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/Test.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/converter/response/Test.java
@@ -1,4 +1,0 @@
-package org.fastcampus.oruryapi.domain.post.converter.response;
-
-public class Test {
-}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/Post.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/Post.java
@@ -7,6 +7,8 @@ import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.fastcampus.oruryapi.domain.user.db.model.User;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @ToString
 @Getter
@@ -39,15 +41,19 @@ public class Post extends AuditingField {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private Post(String title, String content, String images, int category, User user) {
+    private Post(Long id, String title, String content, int viewCount, String images, int category, User user, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
         this.title = title;
         this.content = content;
+        this.viewCount = viewCount;
         this.images = images;
         this.category = category;
         this.user = user;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
-    public static Post of(String title, String content, String images, int category, User user) {
-        return new Post(title, content, images, category, user);
+    public static Post of(Long id, String title, String content, int viewCount, String images, int category, User user, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new Post(id, title, content, viewCount, images, category, user, createdAt, updatedAt);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLike.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLike.java
@@ -1,20 +1,19 @@
 package org.fastcampus.oruryapi.domain.post.db.model;
 
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
+import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Slf4j
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = {"postLikePK"})
+@EqualsAndHashCode(of = {"postLikePK"}, callSuper = false)
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "post_like")
-public class PostLike {
+public class PostLike extends AuditingField {
     @EmbeddedId
     private PostLikePK postLikePK;
 

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLikePK.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/model/PostLikePK.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.fastcampus.oruryapi.domain.user.db.model.User;
 
 import java.io.Serializable;
 
@@ -26,10 +25,10 @@ public class PostLikePK implements Serializable {
         this.postId = postId;
     }
 
-    public PostLikePK of(User user, Post post) {
+    public static PostLikePK of(Long userId, Long postId) {
         return new PostLikePK(
-                user.getId(),
-                post.getId()
+                userId,
+                postId
         );
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostLikeRepository.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostLikeRepository.java
@@ -1,0 +1,9 @@
+package org.fastcampus.oruryapi.domain.post.db.repository;
+
+import org.fastcampus.oruryapi.domain.post.db.model.PostLike;
+import org.fastcampus.oruryapi.domain.post.db.model.PostLikePK;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, PostLikePK> {
+    int countByPostLikePK_PostId(Long postId);
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostLikeRepository.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostLikeRepository.java
@@ -5,5 +5,9 @@ import org.fastcampus.oruryapi.domain.post.db.model.PostLikePK;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, PostLikePK> {
+    PostLike findByPostLikePK_UserIdAndPostLikePK_PostId(Long userId, Long postId);
+
     int countByPostLikePK_PostId(Long postId);
+
+    boolean existsPostLikeByPostLikePK_UserIdAndPostLikePK_PostId(Long userId, Long postId);
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostRepository.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/PostRepository.java
@@ -1,0 +1,17 @@
+package org.fastcampus.oruryapi.domain.post.db.repository;
+
+import org.fastcampus.oruryapi.domain.post.db.model.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByCategoryOrderByIdDesc(int category, Pageable pageable);
+
+    List<Post> findByCategoryAndIdLessThanOrderByIdDesc(int category, Long id, Pageable pageable);
+
+    List<Post> findByTitleContainingOrContentContainingOrderByIdDesc(String titleSearchWord, String contentSearchWord, Pageable pageable);
+
+    List<Post> findByTitleContainingOrContentContainingAndIdLessThanOrderByIdDesc(String titleSearchWord, String contentSearchWord, Long id, Pageable pageable);
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/Test.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/db/repository/Test.java
@@ -1,4 +1,0 @@
-package org.fastcampus.oruryapi.domain.post.db.repository;
-
-public class Test {
-}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/service/PostLikeService.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/service/PostLikeService.java
@@ -1,0 +1,47 @@
+package org.fastcampus.oruryapi.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostLikeDto;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostLikeRequest;
+import org.fastcampus.oruryapi.domain.post.db.model.PostLike;
+import org.fastcampus.oruryapi.domain.post.db.repository.PostLikeRepository;
+import org.fastcampus.oruryapi.domain.post.db.repository.PostRepository;
+import org.fastcampus.oruryapi.domain.user.converter.dto.UserDto;
+import org.fastcampus.oruryapi.domain.user.db.repository.UserRepository;
+import org.fastcampus.oruryapi.global.error.BusinessException;
+import org.fastcampus.oruryapi.global.error.code.PostErrorCode;
+import org.fastcampus.oruryapi.global.error.code.UserErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    public void createPostLike(PostLikeRequest postLikeRequest) {
+        UserDto userDto = UserDto.from(userRepository.findById(postLikeRequest.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND)));
+        PostDto postDto = PostDto.from(postRepository.findById(postLikeRequest.postId())
+                .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND)));
+        PostLike postLike = PostLikeDto.from(PostLike.of(postLikeRequest.toDto(userDto, postDto).toEntity())).toEntity();
+
+        postLikeRepository.save(postLike);
+    }
+
+    public void deletePostLike(PostLikeRequest postLikeRequest) {
+        UserDto userDto = UserDto.from(userRepository.findById(postLikeRequest.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND)));
+        PostDto postDto = PostDto.from(postRepository.findById(postLikeRequest.postId())
+                .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND)));
+        PostLike postLike = postLikeRepository.findByPostLikePK_UserIdAndPostLikePK_PostId(userDto.id(), postDto.id());
+
+        postLikeRepository.delete(postLike);
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/service/PostService.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/post/service/PostService.java
@@ -2,12 +2,111 @@ package org.fastcampus.oruryapi.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryapi.domain.comment.db.repository.CommentRepository;
+import org.fastcampus.oruryapi.domain.post.converter.dto.PostDto;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostCreateRequest;
+import org.fastcampus.oruryapi.domain.post.converter.request.PostUpdateRequest;
+import org.fastcampus.oruryapi.domain.post.converter.response.PostsResponse;
+import org.fastcampus.oruryapi.domain.post.converter.response.PostResponse;
+import org.fastcampus.oruryapi.domain.post.converter.response.PostsWithCursorResponse;
+import org.fastcampus.oruryapi.domain.post.db.model.Post;
+import org.fastcampus.oruryapi.domain.post.db.repository.PostLikeRepository;
+import org.fastcampus.oruryapi.domain.post.db.repository.PostRepository;
+import org.fastcampus.oruryapi.domain.user.converter.dto.UserDto;
+import org.fastcampus.oruryapi.domain.user.db.repository.UserRepository;
+import org.fastcampus.oruryapi.global.constants.Constants;
+import org.fastcampus.oruryapi.global.error.BusinessException;
+import org.fastcampus.oruryapi.global.error.code.PostErrorCode;
+import org.fastcampus.oruryapi.global.error.code.UserErrorCode;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class PostService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void createPost(PostCreateRequest request) {
+        UserDto userDto = UserDto.from(userRepository.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND)));
+        Post post = request.toDto(userDto).toEntity();
+
+        postRepository.save(post);
+    }
+
+    public PostResponse getPostById(Long id) {
+        PostDto postDto = PostDto.from(postRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND)));
+        int likeCount = postLikeRepository.countByPostLikePK_PostId(postDto.id());
+        int commentCount = commentRepository.countByPostId(postDto.id());
+        boolean isLike = postLikeRepository.existsPostLikeByPostLikePK_UserIdAndPostLikePK_PostId(Long.getLong(Constants.USERID.toString()), postDto.id());
+
+        return PostResponse.of(postDto, likeCount, commentCount, isLike);
+    }
+
+    public PostsWithCursorResponse getPostsByCategory(int category, Long cursor, Pageable pageable) {
+        List<Post> posts = (cursor.equals(0L)) // 0L
+                ? postRepository.findByCategoryOrderByIdDesc(category, pageable)
+                : postRepository.findByCategoryAndIdLessThanOrderByIdDesc(category, cursor, pageable);
+
+        return getPostsWithCursorResponse(posts);
+    }
+
+    public PostsWithCursorResponse getPostsBySearchWord(String searchWord, Long cursor, Pageable pageable) {
+        List<Post> posts = (cursor.equals(0L)) // 0L
+                ? postRepository.findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, searchWord, pageable)
+                : postRepository.findByTitleContainingOrContentContainingAndIdLessThanOrderByIdDesc(searchWord, searchWord, cursor, pageable);
+
+        return getPostsWithCursorResponse(posts);
+    }
+
+    @Transactional
+    public void updatePost(PostUpdateRequest request) {
+        PostDto postDto = PostDto.from(postRepository.findById(request.id())
+                .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND)));
+        UserDto userDto = UserDto.from(userRepository.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND)));
+
+        postRepository.save(request.toDto(postDto, userDto).toEntity());
+    }
+
+    @Transactional
+    public void deletePost(Long id) {
+        Post post = postRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
+
+        postRepository.delete(post);
+    }
+
+    @Transactional
+    public void addViewCount(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
+        PostDto postDto = PostDto.of(post.getId(), post.getTitle(), post.getContent(),
+                post.getViewCount() + 1,
+                post.getImages(), post.getCategory(), UserDto.from(post.getUser()), post.getCreatedAt(), post.getUpdatedAt());
+
+        postRepository.save(postDto.toEntity());
+    }
+
+    private PostsWithCursorResponse getPostsWithCursorResponse(List<Post> posts) {
+        List<PostsResponse> postsResponses = posts.stream()
+                .map(post -> {
+                    PostDto postDto = PostDto.from(post);
+                    int likeCount = postLikeRepository.countByPostLikePK_PostId(postDto.id());
+                    int commentCount = commentRepository.countByPostId(postDto.id());
+
+                    return PostsResponse.of(postDto, likeCount, commentCount);
+                }).toList();
+
+        return PostsWithCursorResponse.of(postsResponses);
+    }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/converter/dto/UserDto.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/converter/dto/UserDto.java
@@ -80,13 +80,16 @@ public record UserDto(
 
     public User toEntity() {
         return User.of(
+                id,
                 email,
                 nickname,
                 password,
                 signUpType,
                 gender,
                 birthday,
-                profileImage
+                profileImage,
+                createdAt,
+                updatedAt
         );
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/db/model/User.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/domain/user/db/model/User.java
@@ -7,7 +7,7 @@ import org.fastcampus.oruryapi.base.db.AuditingField;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
-import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Slf4j
 @ToString
@@ -43,7 +43,8 @@ public class User extends AuditingField {
     @Column(name = "profile_image")
     private String profileImage;
 
-    private User(String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage) {
+    private User(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.password = password;
@@ -51,21 +52,11 @@ public class User extends AuditingField {
         this.gender = gender;
         this.birthday = birthday;
         this.profileImage = profileImage;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
-    public static User of(String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage) {
-        return new User(email, nickname, password, signUpType, gender, birthday, profileImage);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof User user)) return false;
-        return Objects.equals(id, user.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
+    public static User of(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new User(id, email, nickname, password, signUpType, gender, birthday, profileImage, createdAt, updatedAt);
     }
 }

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/global/config/JpaAuditingConfig.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.fastcampus.oruryapi.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/global/config/SecurityConfig.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/global/config/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig {
                                 antMatcher("/auth/**"),
                                 antMatcher("/swagger-ui/**"),
                                 antMatcher("/swagger-resources/**"),
+                                antMatcher("/post/**"),
+                                antMatcher("/posts/**"),
                                 PathRequest.toH2Console(),
                                 PathRequest.toStaticResources().atCommonLocations()
                         ).permitAll()

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/global/constants/Constants.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/global/constants/Constants.java
@@ -9,9 +9,17 @@ public enum Constants {
     ROLE_USER("ROLE_USER"),
     ROLE_ADMIN("ROLE_ADMIN"),
 
+    // 초기 커서 입력값
+    FIRST_CURSOR("0"),
+
+    // 조회된 목록이 없음을 나타내는, 마지막 커서 반환값
+    LAST_CURSOR("-1"),
+
+    // 페이지네이션 단위
+    PAGINATION_SIZE("10"),
 
     // userInfo 등 하드 코딩된 것 상수로
-    USERID("userId"),
+    USERID("1L"),
 
     // header 종류
     AUTHORIZATION("Authorization"),

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/global/error/code/PostErrorCode.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/global/error/code/PostErrorCode.java
@@ -1,0 +1,23 @@
+package org.fastcampus.oruryapi.global.error.code;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "게시글이 존재하지 않습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT.value(), "조회된 게시글이 없습니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/orury-api/src/main/java/org/fastcampus/oruryapi/global/message/info/InfoMessage.java
+++ b/orury-api/src/main/java/org/fastcampus/oruryapi/global/message/info/InfoMessage.java
@@ -7,9 +7,12 @@ public enum InfoMessage {
 
     // 게시글
     POST_CREATED("게시글이 생성되었습니다."),
-    POST_DELETED("게시글이 삭제되었습니다."),
+    POST_READ("게시글을 조회했습니다."),
+    POSTS_READ("게시글 목록을 조회했습니다."),
     POST_UPDATED("게시글이 수정되었습니다"),
-    POST_LIKE_UPDATED("게시글 좋아요 상태가 업데이트 되었습니다."),
+    POST_DELETED("게시글이 삭제되었습니다."),
+    POST_LIKE_CREATED("게시글 좋아요가 생성되었습니다."),
+    POST_LIKE_DELETED("게시글 좋아요가 삭제되었습니다."),
 
     // 댓글
     COMMENT_CREATED("댓글이 생성되었습니다."),

--- a/orury-core/src/main/resources/db/migration/V1.0.0__init.sql
+++ b/orury-core/src/main/resources/db/migration/V1.0.0__init.sql
@@ -1,13 +1,14 @@
 CREATE TABLE `post` (
-                        `id`	bigint(32)	NOT NULL	COMMENT '게시글 아이디',
+                        `id`	bigint(32)	NOT NULL AUTO_INCREMENT,
                         `title`	varchar(50)	NOT NULL,
                         `content`	text	NOT NULL,
-                        `view_count`	int	NOT NULL	DEFAULT 0,
+                        `view_count`	int	NOT NULL,
                         `images`	varchar(255)	NULL	COMMENT 'List<String>',
                         `category`	int	NOT NULL	COMMENT '1 : 자유게시판 2 : Q&A',
                         `user_id`	bigint(32)	NOT NULL,
                         `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                        `updated_at`	DATETIME	NULL
+                        `updated_at`	DATETIME	NULL,
+                        PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `post_like` (
@@ -18,17 +19,17 @@ CREATE TABLE `post_like` (
 );
 
 CREATE TABLE `user` (
-                        `id`	bigint(32)	NOT NULL,
+                        `id`	bigint(32)	NOT NULL AUTO_INCREMENT,
                         `email`	varchar(50)	NOT NULL,
                         `nickname`	varchar(8)	NOT NULL,
                         `password`	varchar(100)	NOT NULL,
                         `sign_up_type`	int	NOT NULL	COMMENT '1 : 카카오 로그인 2 : 구글 로그인',
                         `gender`	int	NOT NULL	COMMENT '1 : 남성 2: 여성',
                         `birthday`	date	NOT NULL,
-                        `type`	int	NOT NULL	DEFAULT 1	COMMENT '1 : 유저 2 : 어드민 3 : 사장님',
                         `profile_image`	varchar(50)	NULL,
                         `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                        `updated_at`	DATETIME	NULL
+                        `updated_at`	DATETIME	NULL,
+                        PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `comment_like` (
@@ -39,45 +40,49 @@ CREATE TABLE `comment_like` (
 );
 
 CREATE TABLE `comment` (
-                           `id`	BIGINT(32)	NOT NULL,
+                           `id`	BIGINT(32)	NOT NULL AUTO_INCREMENT,
                            `content`	VARCHAR(1000)	NOT NULL,
                            `parent_id`	BIGINT(32)	NOT NULL	DEFAULT 0	COMMENT '부모 댓글이 없으면 일반 댓글, 있으면 대댓',
                            `post_id`	BIGINT(32)	NOT NULL	COMMENT '게시글 아이디',
                            `user_id`	BIGINT(32)	NOT NULL,
                            `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                           `updated_at`	DATETIME	NULL
+                           `updated_at`	DATETIME	NULL,
+                           PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `refresh_token` (
-                                 `id`	bigint(32)	NOT NULL,
+                                 `id`	bigint(32)	NOT NULL AUTO_INCREMENT,
                                  `user_id`	bigint(32)	NOT NULL,
                                  `value`	varchar(255)	NOT NULL,
                                  `expiration_time`	datetime	NOT NULL,
                                  `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                                 `updated_at`	DATETIME	NULL
+                                 `updated_at`	DATETIME	NULL,
+                                 PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `Notice` (
-                          `id`	BIGINT(32)	NOT NULL,
+                          `id`	BIGINT(32)	NOT NULL AUTO_INCREMENT,
                           `title`	VARCHAR(50)	NOT NULL,
                           `content`	VARCHAR(50)	NOT NULL,
                           `admin_id`	BIGINT(32)	NOT NULL,
                           `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                          `updated_at`	DATETIME	NULL
+                          `updated_at`	DATETIME	NULL,
+                          PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `Admin` (
-                         `id`	BIGINT(32)	NOT NULL,
+                         `id`	BIGINT(32)	NOT NULL AUTO_INCREMENT,
                          `name`	VARCHAR(50)	NOT NULL,
                          `email`	VARCHAR(50)	NOT NULL,
                          `password`	VARCHAR(50)	NOT NULL,
                          `role` VARCHAR(50) NOT NULL,
                          `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                         `updated_at`	DATETIME	NULL
+                         `updated_at`	DATETIME	NULL,
+                         PRIMARY KEY(`id`)
 );
 
 CREATE TABLE `user_withdrawal` (
-                                   `id`	BIGINT(32)	NOT NULL,
+                                   `id`	BIGINT(32)	NOT NULL AUTO_INCREMENT,
                                    `email`	VARCHAR(50)	NOT NULL,
                                    `nickname`	VARCHAR(8)	NOT NULL,
                                    `password`	VARCHAR(100)	NOT NULL,
@@ -85,46 +90,18 @@ CREATE TABLE `user_withdrawal` (
                                    `gender`	int	NOT NULL	COMMENT '1 : 남성 2: 여성',
                                    `birthday`	date	NOT NULL,
                                    `created_at`	DATETIME	NOT NULL	COMMENT '@CreatedDate',
-                                   `updated_at`	DATETIME	NULL
+                                   `updated_at`	DATETIME	NULL,
+                                   PRIMARY KEY(`id`)
 );
-
-ALTER TABLE `post` ADD CONSTRAINT `PK_POST` PRIMARY KEY (
-                                                         `id`
-    );
 
 ALTER TABLE `post_like` ADD CONSTRAINT `PK_POST_LIKE` PRIMARY KEY (
                                                                    `user_id`,
                                                                    `post_id`
     );
 
-ALTER TABLE `user` ADD CONSTRAINT `PK_USER` PRIMARY KEY (
-                                                         `id`
-    );
-
 ALTER TABLE `comment_like` ADD CONSTRAINT `PK_COMMENT_LIKE` PRIMARY KEY (
                                                                          `user_id`,
                                                                          `comment_id`
-    );
-
-ALTER TABLE `comment` ADD CONSTRAINT `PK_COMMENT` PRIMARY KEY (
-                                                               `id`
-    );
-
-ALTER TABLE `refresh_token` ADD CONSTRAINT `PK_REFRESH_TOKEN` PRIMARY KEY (
-                                                                           `id`,
-                                                                           `user_id`
-    );
-
-ALTER TABLE `Notice` ADD CONSTRAINT `PK_NOTICE` PRIMARY KEY (
-                                                             `id`
-    );
-
-ALTER TABLE `Admin` ADD CONSTRAINT `PK_ADMIN` PRIMARY KEY (
-                                                           `id`
-    );
-
-ALTER TABLE `user_withdrawal` ADD CONSTRAINT `PK_USER_WITHDRAWAL` PRIMARY KEY (
-                                                                               `id`
     );
 
 ALTER TABLE `post_like` ADD CONSTRAINT `FK_user_TO_post_like_1` FOREIGN KEY (

--- a/orury-core/src/main/resources/db/migration/V1.0.1__drop_user_type.sql
+++ b/orury-core/src/main/resources/db/migration/V1.0.1__drop_user_type.sql
@@ -1,2 +1,0 @@
-alter table user
-drop column type;


### PR DESCRIPTION
## 개요
commit별로 구현/변경 사항을 작성했기에, Commit 순서대로 읽으시길 추천드립니다! 그리고 피드백은 언제나 환영입니다:)
### Chore : 기존 Entity 수정 
- Post : 생성자 메서드에 빠진 필드 추가.
- PostLike : AuditingField 상속. (createdAt 필요)
- PostLikePK : 생성자 메서드 수정.
- User : 생성자 메서드에 빠진 필드 추가 및 equels,hashCode 메서드 중복 삭제
### Chore : initiation sql 수정
- AUTO_INCREMENT가 없어 id 자동 생성 문제가 있어, 추가했습니다.
- 이에 따른, PrimaryKey 지정이 각 테이블에서 필요하여 PK 명시하는 부분 이동시켰습니다.
### Chore : Dto toEntity() 수정
- toEntity메서드의 반환값에 id가 안 담겨 있던 부분 수정했습니다.
### Feat : 기본 CRUD를 위한 Config 설정
- @EnableJpaAuditing을 메인클래스에 작성하기보다, 따로 config 폴더에 클래스로 따로 뺐습니다.
- SecurityConfig에 post(게시글)를 위한 경로를 추가했습니다.
### Feat : Post(게시글) 관련 CRUD 기능 구현
- api마다 필요한 Request와 Response를 생성했습니다.
- 게시글 카테고리별 조회와 게시글 검색 조회는 PostsResponse를 같이 쓰고(화면에 띄우는 정보가 동일하기 때문), PostsWithCursorResponse로 최종 api 응답을 합니다.(프론트에서 cursor 정보(조회 마지막 아이템의 id)를 필요로 해서 따로 담는 과정을 추가했습니다.)
- Cursor 기반 페이지네이션을 구현했습니다. Spring Data Jpa로 구현했습니다.
- DB에 저장되는 image 양식을 몰라, 우선은 String으로 작성했고, 게시글 썸네일이미지 추출도 보완 필요합니다.
- Constants를 활용해서 상수처리를 하고 싶었는데, int와 Long의 값이 제대로 인식되지 않아, 이 부분 보완 필요합니다.
  - 보완 필요한 부분: PostController, PostService, PostsWithCursorResponse
### Feat : PostLike(게시글좋아요) 기능 구현
- PostLike, PostLikePK 모두 Dto를 활용하여 구현했습니다.
### Chore : Delete Unused File

closed #28

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
