### PR TITLE
Refactor : API 응답 isMine 추가에 따른 리팩토링

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/controller/CommentController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/controller/CommentController.java
@@ -58,7 +58,7 @@ public class CommentController {
         List<CommentResponse> commentResponses = commentDtos.stream()
                 .map(commentDto -> {
                     boolean isLike = commentLikeService.isLiked(NumberConstants.USER_ID, commentDto.id());
-                    return CommentResponse.of(commentDto, isLike);
+                    return CommentResponse.of(commentDto, NumberConstants.USER_ID, isLike);
                 }).toList();
 
         CommentsWithCursorResponse response = CommentsWithCursorResponse.of(commentResponses);

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/converter/response/CommentResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/converter/response/CommentResponse.java
@@ -2,9 +2,8 @@ package org.fastcampus.oruryclient.comment.converter.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import org.fastcampus.orurydomain.comment.dto.CommentDto;
 import org.fastcampus.oruryclient.global.constants.Constants;
-import org.fastcampus.oruryclient.global.constants.NumberConstants;
+import org.fastcampus.orurydomain.comment.dto.CommentDto;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +13,7 @@ public record CommentResponse(
         String content,
         Long parentId,
         int likeCount,
-        Long userId,
+        boolean isMine,
         String userNickname,
         String userProfileImage,
         LocalDateTime createdAt,
@@ -22,13 +21,13 @@ public record CommentResponse(
         boolean isLike,
         int deleted
 ) {
-    public static CommentResponse of(CommentDto commentDto, boolean isLike) {
+    public static CommentResponse of(CommentDto commentDto, Long userId, boolean isLike) {
         return new CommentResponse(
                 commentDto.id(),
                 commentDto.content(),
                 commentDto.parentId(),
                 commentDto.likeCount(),
-                (commentDto.deleted() == 1) ? NumberConstants.DELETED_USER_ID : commentDto.userDto().id(),
+                (commentDto.deleted() == 1) ? false : commentDto.userDto().id().equals(userId),
                 (commentDto.deleted() == 1) ? Constants.DELETED_USER.getMessage() : commentDto.userDto().nickname(),
                 (commentDto.deleted() == 1) ? Constants.DELETED_USER.getMessage() : commentDto.userDto().profileImage(),
                 commentDto.createdAt(),

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/service/CommentLikeService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/service/CommentLikeService.java
@@ -12,12 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class CommentLikeService {
     private final CommentLikeRepository commentLikeRepository;
     private final CommentRepository commentRepository;
 
+    @Transactional
     public void createCommentLike(CommentLikeDto commentLikeDto) {
         commentRepository.findById(commentLikeDto.commentLikePK().getCommentId())
                         .orElseThrow(() -> new BusinessException(CommentErrorCode.NOT_FOUND));
@@ -27,6 +27,7 @@ public class CommentLikeService {
         commentRepository.increaseLikeCount(commentLikeDto.commentLikePK().getCommentId());
     }
 
+    @Transactional
     public void deleteCommentLike(CommentLikeDto commentLikeDto) {
         commentRepository.findById(commentLikeDto.commentLikePK().getCommentId())
                 .orElseThrow(() -> new BusinessException(CommentErrorCode.NOT_FOUND));
@@ -36,6 +37,7 @@ public class CommentLikeService {
         commentRepository.decreaseLikeCount(commentLikeDto.commentLikePK().getCommentId());
     }
 
+    @Transactional(readOnly = true)
     public boolean isLiked(Long userId, Long commentId) {
         return commentLikeRepository.existsCommentLikeByCommentLikePK_UserIdAndCommentLikePK_CommentId(userId, commentId);
     }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/service/CommentService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/service/CommentService.java
@@ -41,6 +41,7 @@ public class CommentService {
         postRepository.increaseCommentCount(commentDto.postDto().id());
     }
 
+    @Transactional(readOnly = true)
     public List<CommentDto> getCommentDtosByPost(PostDto postDto, Long cursor, Pageable pageable) {
         List<Comment> parentComments = (cursor.equals(NumberConstants.LAST_CURSOR))
                 ? new ArrayList<>()
@@ -86,6 +87,7 @@ public class CommentService {
             throw new BusinessException(CommentErrorCode.FORBIDDEN);
     }
 
+    @Transactional(readOnly = true)
     public void isValidate(CommentLikeDto commentLikeDto) {
         Comment comment = commentRepository.findById(commentLikeDto.commentLikePK().getCommentId())
                 .orElseThrow(() -> new BusinessException(CommentErrorCode.NOT_FOUND));
@@ -93,6 +95,7 @@ public class CommentService {
             throw new BusinessException(CommentErrorCode.FORBIDDEN);
     }
 
+    @Transactional(readOnly = true)
     public CommentDto getCommentDtoById(Long id){
         Comment comment = commentRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(CommentErrorCode.NOT_FOUND));

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
@@ -36,7 +36,7 @@ public class PostController {
     @Operation(summary = "게시글 생성", description = "게시글 정보를 받아, 게시글을 생성한다.")
     @PostMapping("/post")
     public ApiResponse<Object> createPost(@RequestBody PostCreateRequest request) {
-        UserDto userDto = userService.getUserDtoById(request.userId());
+        UserDto userDto = userService.getUserDtoById(NumberConstants.USER_ID);
         PostDto postDto = request.toDto(userDto);
 
         postService.createPost(postDto);
@@ -116,7 +116,7 @@ public class PostController {
     @Operation(summary = "게시글 수정", description = "게시글 정보를 받아, 게시글을 수정한다.")
     @PatchMapping("/post")
     public ApiResponse<Object> updatePost(@RequestBody PostUpdateRequest request) {
-        UserDto userDto = userService.getUserDtoById(request.userId());
+        UserDto userDto = userService.getUserDtoById(NumberConstants.USER_ID);
         PostDto postDto = postService.getPostDtoById(request.id());
         postService.isValidate(postDto, userDto);
 

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
         postService.addViewCount(postDto);
 
         boolean isLike = postLikeService.isLiked(NumberConstants.USER_ID, id);
-        PostResponse response = PostResponse.of(postDto, isLike);
+        PostResponse response = PostResponse.of(postDto, NumberConstants.USER_ID, isLike);
 
         return ApiResponse.<PostResponse>builder()
                 .status(HttpStatus.OK.value())

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/request/PostCreateRequest.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/request/PostCreateRequest.java
@@ -2,21 +2,18 @@ package org.fastcampus.oruryclient.post.converter.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.orurydomain.post.dto.PostDto;
 import org.fastcampus.orurydomain.user.dto.UserDto;
 
-@Slf4j
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PostCreateRequest(
         String title,
         String content,
         String images,
-        int category,
-        Long userId
+        int category
 ) {
-    public static PostCreateRequest of(String title, String content, String images, int category, Long userId) {
-        return new PostCreateRequest(title, content, images, category, userId);
+    public static PostCreateRequest of(String title, String content, String images, int category) {
+        return new PostCreateRequest(title, content, images, category);
     }
 
     public PostDto toDto(UserDto userDto) {

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/request/PostUpdateRequest.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/request/PostUpdateRequest.java
@@ -2,22 +2,19 @@ package org.fastcampus.oruryclient.post.converter.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.orurydomain.post.dto.PostDto;
 import org.fastcampus.orurydomain.user.dto.UserDto;
 
-@Slf4j
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record PostUpdateRequest(
         Long id,
         String title,
         String content,
         String images,
-        int category,
-        Long userId
+        int category
 ) {
-    public static PostUpdateRequest of(Long id, String title, String content, String images, int category, Long userId) {
-        return new PostUpdateRequest(id, title, content, images, category, userId);
+    public static PostUpdateRequest of(Long id, String title, String content, String images, int category) {
+        return new PostUpdateRequest(id, title, content, images, category);
     }
 
     public PostDto toDto(PostDto postDto, UserDto userDto) {

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostResponse.java
@@ -18,12 +18,12 @@ public record PostResponse(
         int category,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        Long userId,
+        boolean isMine,
         String userNickname,
         String userProfileImage,
         boolean isLike
 ) {
-    public static PostResponse of(PostDto postDto, boolean isLike) {
+    public static PostResponse of(PostDto postDto, Long userId, boolean isLike) {
         return new PostResponse(
                 postDto.id(),
                 postDto.title(),
@@ -35,7 +35,7 @@ public record PostResponse(
                 postDto.category(),
                 postDto.createdAt(),
                 postDto.updatedAt(),
-                postDto.userDto().id(),
+                postDto.userDto().id().equals(userId),
                 postDto.userDto().nickname(),
                 postDto.userDto().profileImage(),
                 isLike

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/service/PostLikeService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/service/PostLikeService.java
@@ -12,12 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
 
+    @Transactional
     public void createPostLike(PostLikeDto postLikeDto) {
         postRepository.findById(postLikeDto.postLikePK().getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
@@ -27,6 +27,7 @@ public class PostLikeService {
         postRepository.increaseLikeCount(postLikeDto.postLikePK().getPostId());
     }
 
+    @Transactional
     public void deletePostLike(PostLikeDto postLikeDto) {
         postRepository.findById(postLikeDto.postLikePK().getPostId())
                 .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
@@ -36,6 +37,7 @@ public class PostLikeService {
         postRepository.decreaseLikeCount(postLikeDto.postLikePK().getPostId());
     }
 
+    @Transactional(readOnly = true)
     public boolean isLiked(Long userId, Long postId){
         return postLikeRepository.existsPostLikeByPostLikePK_UserIdAndPostLikePK_PostId(userId, postId);
     }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/service/PostService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/service/PostService.java
@@ -36,6 +36,7 @@ public class PostService {
         postRepository.save(postDto.toEntity());
     }
 
+    @Transactional(readOnly = true)
     public List<PostDto> getPostDtosByCategory(int category, Long cursor, Pageable pageable) {
         List<Post> posts = (cursor.equals(NumberConstants.FIRST_CURSOR))
                 ? postRepository.findByCategoryOrderByIdDesc(category, pageable)
@@ -45,6 +46,7 @@ public class PostService {
                 .map(PostDto::from).toList();
     }
 
+    @Transactional(readOnly = true)
     public List<PostDto> getPostDtosBySearchWord(String searchWord, Long cursor, Pageable pageable) {
         List<Post> posts = (cursor.equals(NumberConstants.FIRST_CURSOR))
                 ? postRepository.findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, searchWord, pageable)
@@ -54,6 +56,7 @@ public class PostService {
                 .map(PostDto::from).toList();
     }
 
+    @Transactional(readOnly = true)
     public Page<PostDto> getHotPostDtos(Pageable pageable) {
         Page<Post> posts = postRepository.findByLikeCountGreaterThanEqualAndCreatedAtGreaterThanEqualOrderByLikeCountDescCreatedAtDesc
                 (NumberConstants.HOT_POSTS_BOUNDARY, LocalDateTime.now().minusMonths(1L), pageable);
@@ -85,6 +88,7 @@ public class PostService {
         postRepository.updateViewCount(postDto.id());
     }
 
+    @Transactional(readOnly = true)
     public PostDto getPostDtoById(Long id) {
         Post post = postRepository.findById(id).orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
         return PostDto.from(post);


### PR DESCRIPTION
## 개요
### Refactor : 조회 API 응답에 is_mine 추가 및 user_id 삭제
- 프론트에서 userId 제공하지 않는 것으로 금일 회의한 바에 따라,
- userId 대신 isMine을 응답하는 것으로 수정했습니다.
### Refactor : PostCreateRequest와 PostUpdateRequest에 userId 삭제
- 프론트에서 userId 요청에 담지 않음에 따라, Post 관련 request에 userId를 삭제했습니다.
### Refactor : 조회만 수행하는 Service 메서드에 @transactional(readOnly = true) 추가
- 기존에는 생성/수정/삭제를 수행하는 메서드에 한해서만 @**Transactional**을 붙여 롤백이 가능하도록 했습니다.
- 그러나 KernelSquare팀의 레포를 참고하고 검색해본 결과, 
- @**Transactional**(readOnly = true)를 다는 것이 조회만 수행하는 메서드에서도 성능 향상을 가져온다고 합니다.
  - (readOnly = true)에 대한 설명은 [이 링크](https://velog.io/@jhbae0420/TransactionalreadOnly-true%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0%EC%99%80-%EC%A3%BC%EC%9D%98%ED%95%A0%EC%A0%90) 참고하시면 도움이 될 듯 합니다!

closed #74 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
