### PR TITLE
Refactor : Post '검색결과 없음'과 'Pagination 종료'에 대한 cursor 응답 구분

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/global/constants/NumberConstants.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/global/constants/NumberConstants.java
@@ -10,6 +10,8 @@ public final class NumberConstants {
     public static final Long FIRST_CURSOR = 0L;
     // Last Pagination Cursor Return Value
     public static final Long LAST_CURSOR = -1L;
+    // First Page But Nothing Cursor Return Value
+    public static final Long NOTHING_CURSOR = -2L;
     // Post pagination Size
     public static final int POST_PAGINATION_SIZE = 10;
     // Comment pagination Size

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
@@ -3,8 +3,7 @@ package org.fastcampus.oruryclient.post.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.fastcampus.orurydomain.base.converter.ApiResponse;
-import org.fastcampus.orurydomain.post.dto.PostDto;
+import org.fastcampus.oruryclient.global.constants.NumberConstants;
 import org.fastcampus.oruryclient.post.converter.request.PostCreateRequest;
 import org.fastcampus.oruryclient.post.converter.request.PostUpdateRequest;
 import org.fastcampus.oruryclient.post.converter.response.PostResponse;
@@ -14,9 +13,10 @@ import org.fastcampus.oruryclient.post.converter.response.PostsWithPageResponse;
 import org.fastcampus.oruryclient.post.service.PostLikeService;
 import org.fastcampus.oruryclient.post.service.PostService;
 import org.fastcampus.oruryclient.post.util.PostMessage;
-import org.fastcampus.orurydomain.user.dto.UserDto;
 import org.fastcampus.oruryclient.user.service.UserService;
-import org.fastcampus.oruryclient.global.constants.NumberConstants;
+import org.fastcampus.orurydomain.base.converter.ApiResponse;
+import org.fastcampus.orurydomain.post.dto.PostDto;
+import org.fastcampus.orurydomain.user.dto.UserDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -71,7 +71,7 @@ public class PostController {
         List<PostsResponse> postsResponses = postDtos.stream()
                 .map(PostsResponse::of).toList();
 
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses);
+        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses, cursor);
 
         return ApiResponse.<PostsWithCursorResponse>builder()
                 .status(HttpStatus.OK.value())
@@ -87,7 +87,7 @@ public class PostController {
         List<PostsResponse> postsResponses = postDtos.stream()
                 .map(PostsResponse::of).toList();
 
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses);
+        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses, cursor);
 
         return ApiResponse.<PostsWithCursorResponse>builder()
                 .status(HttpStatus.OK.value())

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostsWithCursorResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostsWithCursorResponse.java
@@ -11,12 +11,18 @@ public record PostsWithCursorResponse(
         List<PostsResponse> posts,
         Long cursor
 ) {
-    public static PostsWithCursorResponse of(List<PostsResponse> posts) {
+    public static PostsWithCursorResponse of(List<PostsResponse> posts, Long cursor) {
 
-        Long cursor = (posts.isEmpty())
-                ? NumberConstants.LAST_CURSOR
+        Long newCursor = (posts.isEmpty())
+                ? determineCursorWhenEmpty(cursor)
                 : posts.get(posts.size() - 1).id();
 
-        return new PostsWithCursorResponse(posts, cursor);
+        return new PostsWithCursorResponse(posts, newCursor);
+    }
+
+    private static Long determineCursorWhenEmpty(Long cursor) {
+        return cursor.equals(NumberConstants.FIRST_CURSOR)
+                ? NumberConstants.NOTHING_CURSOR
+                : NumberConstants.LAST_CURSOR;
     }
 }


### PR DESCRIPTION
## 개요
### refactor : Post 검색결과 없음과 스크롤 종료에 대한 cursor 응답 구분
- PostsWithCursorResponse의 생성자 인자로 api 요청에서 받은 cursor값을 받아,
- 첫 페이지네이션 조회면서 조회된 데이터가 없는 경우 -2L를 응답하도록 구현했습니다.

closed #117
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
