### PR TITLE
Test: 암장 도메인 Service 테스트코드 작성

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/gym/controller/GymLikeController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/gym/controller/GymLikeController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/gyms/like")
 @RestController
 public class GymLikeController {
     private final GymLikeService gymLikeService;
     private final GymService gymService;
 
     @Operation(summary = "암장 좋아요 생성", description = "암장 id를 받아, 암장 좋아요를 생성한다.")
-    @PostMapping("/gym/like/{gymId}")
+    @PostMapping("/{gymId}")
     public ApiResponse<Object> createGymLike(@PathVariable Long gymId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         gymService.isValidate(gymId);
         GymLikeDto gymLikeDto = GymLikeDto.from(GymLike.of(GymLikePK.of(userPrincipal.id(), gymId)));
@@ -38,7 +38,7 @@ public class GymLikeController {
     }
 
     @Operation(summary = "암장 좋아요 삭제", description = "암장 id를 받아, 암장 좋아요를 삭제한다.")
-    @DeleteMapping("/gym/like/{gymId}")
+    @DeleteMapping("/{gymId}")
     public ApiResponse<Object> deleteGymLike(@PathVariable Long gymId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         gymService.isValidate(gymId);
         GymLikeDto gymLikeDto = GymLikeDto.from(GymLike.of(GymLikePK.of(userPrincipal.id(), gymId)));

--- a/orury-client/src/main/resources/application.yml
+++ b/orury-client/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       allowed-origins: "*"
       allowed-methods: "GET, POST, PUT, DELETE"
   application.name: orury-client
-  ddatasource:
+  datasource:
     #url: ${LOCAL_DB_NAME}
     url: ENC(+jNy+HRl5S5QeokxoLB89WTqqqa7EGm73Cpm2N4KXnu1yH3puewQxOUDussQQ9Qd)
     #username: ${LOCAL_DB_USER_NAME}

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
@@ -16,7 +16,7 @@ import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GymLikeServiceTest")
+@DisplayName("[Service] 암장 좋아요 테스트")
 @ActiveProfiles("test")
 class GymLikeServiceTest {
 

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
@@ -38,15 +38,19 @@ class GymLikeServiceTest {
         GymLikePK gymLikePK = GymLikePK.of(2L, 1L);
         GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
 
-        given(gymLikeRepository.existsById(gymLikePK)).willReturn(false);
+        given(gymLikeRepository.existsById(gymLikePK))
+                .willReturn(false);
 
         // when
         gymLikeService.createGymLike(gymLikeDto);
 
         //then
-        then(gymLikeRepository).should().existsById(any());
-        then(gymLikeRepository).should().save(any());
-        then(gymRepository).should().increaseLikeCount(anyLong());
+        then(gymLikeRepository).should()
+                .existsById(any());
+        then(gymLikeRepository).should()
+                .save(any());
+        then(gymRepository).should()
+                .increaseLikeCount(anyLong());
     }
 
     @Test
@@ -56,15 +60,19 @@ class GymLikeServiceTest {
         GymLikePK gymLikePK = GymLikePK.of(1L, 2L);
         GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
 
-        given(gymLikeRepository.existsById(gymLikePK)).willReturn(true);
+        given(gymLikeRepository.existsById(gymLikePK))
+                .willReturn(true);
 
         // when
         gymLikeService.createGymLike(gymLikeDto);
 
         //then
-        then(gymLikeRepository).should().existsById(any());
-        then(gymLikeRepository).should(never()).save(any());
-        then(gymRepository).should(never()).increaseLikeCount(anyLong());
+        then(gymLikeRepository).should().
+                existsById(any());
+        then(gymLikeRepository).should(never())
+                .save(any());
+        then(gymRepository).should(never())
+                .increaseLikeCount(anyLong());
     }
 
     @Test
@@ -74,15 +82,19 @@ class GymLikeServiceTest {
         GymLikePK gymLikePK = GymLikePK.of(4L, 3L);
         GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
 
-        given(gymLikeRepository.existsById(gymLikePK)).willReturn(true);
+        given(gymLikeRepository.existsById(gymLikePK))
+                .willReturn(true);
 
         // when
         gymLikeService.deleteGymLike(gymLikeDto);
 
         //then
-        then(gymLikeRepository).should().existsById(any());
-        then(gymLikeRepository).should().delete(any());
-        then(gymRepository).should().decreaseLikeCount(anyLong());
+        then(gymLikeRepository).should()
+                .existsById(any());
+        then(gymLikeRepository).should()
+                .delete(any());
+        then(gymRepository).should()
+                .decreaseLikeCount(anyLong());
     }
 
     @Test
@@ -92,15 +104,19 @@ class GymLikeServiceTest {
         GymLikePK gymLikePK = GymLikePK.of(3L, 4L);
         GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
 
-        given(gymLikeRepository.existsById(gymLikePK)).willReturn(false);
+        given(gymLikeRepository.existsById(gymLikePK))
+                .willReturn(false);
 
         // when
         gymLikeService.deleteGymLike(gymLikeDto);
 
         //then
-        then(gymLikeRepository).should().existsById(any());
-        then(gymLikeRepository).should(never()).delete(any());
-        then(gymRepository).should(never()).decreaseLikeCount(anyLong());
+        then(gymLikeRepository).should()
+                .existsById(any());
+        then(gymLikeRepository).should(never())
+                .delete(any());
+        then(gymRepository).should(never())
+                .decreaseLikeCount(anyLong());
     }
 
     @Test
@@ -110,7 +126,8 @@ class GymLikeServiceTest {
         Long userId = 1L;
         Long gymId = 2L;
 
-        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L)).willReturn(true);
+        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L))
+                .willReturn(true);
 
         boolean expectedValue = true;
 
@@ -118,8 +135,10 @@ class GymLikeServiceTest {
         boolean isLiked = gymLikeService.isLiked(userId, gymId);
 
         //then
-        then(isLiked).equals(expectedValue);
-        then(gymLikeRepository).should().existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
+        then(isLiked)
+                .equals(expectedValue);
+        then(gymLikeRepository).should()
+                .existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
     }
 
     @Test
@@ -129,7 +148,8 @@ class GymLikeServiceTest {
         Long userId = 1L;
         Long gymId = 2L;
 
-        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L)).willReturn(false);
+        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L))
+                .willReturn(false);
 
         boolean expectedValue = false;
 
@@ -137,8 +157,10 @@ class GymLikeServiceTest {
         boolean isLiked = gymLikeService.isLiked(userId, gymId);
 
         //then
-        then(isLiked).equals(expectedValue);
-        then(gymLikeRepository).should().existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
+        then(isLiked)
+                .equals(expectedValue);
+        then(gymLikeRepository).should()
+                .existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
     }
 
     private static GymLikeDto createGymLikeDto(GymLikePK gymLikePK) {

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymLikeServiceTest.java
@@ -1,4 +1,147 @@
 package org.fastcampus.oruryclient.gym.service;
 
-public class GymLikeServiceTest {
+import org.fastcampus.orurydomain.gym.db.model.GymLike;
+import org.fastcampus.orurydomain.gym.db.model.GymLikePK;
+import org.fastcampus.orurydomain.gym.db.repository.GymLikeRepository;
+import org.fastcampus.orurydomain.gym.db.repository.GymRepository;
+import org.fastcampus.orurydomain.gym.dto.GymLikeDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GymLikeServiceTest")
+@ActiveProfiles("test")
+class GymLikeServiceTest {
+
+    private GymLikeService gymLikeService;
+    private GymLikeRepository gymLikeRepository;
+    private GymRepository gymRepository;
+
+    @BeforeEach
+    void setUp() {
+        gymLikeRepository = mock(GymLikeRepository.class);
+        gymRepository = mock(GymRepository.class);
+        gymLikeService = new GymLikeService(gymLikeRepository, gymRepository);
+    }
+
+    @Test
+    @DisplayName("암장에 대한 유저의 암장 좋아요 기존에 없다면, 정상적으로 암장 좋아요를 생성한다.")
+    void should_CreateGymLike() {
+        //given
+        GymLikePK gymLikePK = GymLikePK.of(2L, 1L);
+        GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
+
+        given(gymLikeRepository.existsById(gymLikePK)).willReturn(false);
+
+        // when
+        gymLikeService.createGymLike(gymLikeDto);
+
+        //then
+        then(gymLikeRepository).should().existsById(any());
+        then(gymLikeRepository).should().save(any());
+        then(gymRepository).should().increaseLikeCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("암장에 대한 유저의 암장 좋아요 기존에 있다면, 생성하지 않고 return한다.")
+    void when_AlreadyExistingGymLike_Then_ReturnWithoutSave() {
+        //given
+        GymLikePK gymLikePK = GymLikePK.of(1L, 2L);
+        GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
+
+        given(gymLikeRepository.existsById(gymLikePK)).willReturn(true);
+
+        // when
+        gymLikeService.createGymLike(gymLikeDto);
+
+        //then
+        then(gymLikeRepository).should().existsById(any());
+        then(gymLikeRepository).should(never()).save(any());
+        then(gymRepository).should(never()).increaseLikeCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("암장에 대한 유저의 암장 좋아요 기존에 있다면, 정상적으로 암장 좋아요를 삭제한다.")
+    void should_DeleteGymLike() {
+        //given
+        GymLikePK gymLikePK = GymLikePK.of(4L, 3L);
+        GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
+
+        given(gymLikeRepository.existsById(gymLikePK)).willReturn(true);
+
+        // when
+        gymLikeService.deleteGymLike(gymLikeDto);
+
+        //then
+        then(gymLikeRepository).should().existsById(any());
+        then(gymLikeRepository).should().delete(any());
+        then(gymRepository).should().decreaseLikeCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("암장에 대한 유저의 암장 좋아요 기존에 없다면, 삭제하지 않고 return한다.")
+    void when_NotExistingGymLike_Then_ReturnWithoutDelete() {
+        //given
+        GymLikePK gymLikePK = GymLikePK.of(3L, 4L);
+        GymLikeDto gymLikeDto = createGymLikeDto(gymLikePK);
+
+        given(gymLikeRepository.existsById(gymLikePK)).willReturn(false);
+
+        // when
+        gymLikeService.deleteGymLike(gymLikeDto);
+
+        //then
+        then(gymLikeRepository).should().existsById(any());
+        then(gymLikeRepository).should(never()).delete(any());
+        then(gymRepository).should(never()).decreaseLikeCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("유저id와 암장id에 대해 좋아요가 존재하면, true를 반환한다.")
+    void when_idsOfExitingGymLike_Then_ReturnTrue() {
+        //given
+        Long userId = 1L;
+        Long gymId = 2L;
+
+        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L)).willReturn(true);
+
+        boolean expectedValue = true;
+
+        // when
+        boolean isLiked = gymLikeService.isLiked(userId, gymId);
+
+        //then
+        then(isLiked).equals(expectedValue);
+        then(gymLikeRepository).should().existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("유저id와 암장id에 대해 좋아요가 존재하지 않으면, false를 반환한다.")
+    void when_idsOfNotExitingGymLike_Then_ReturnFalse() {
+        //given
+        Long userId = 1L;
+        Long gymId = 2L;
+
+        given(gymLikeRepository.existsByGymLikePK_UserIdAndGymLikePK_GymId(1L, 2L)).willReturn(false);
+
+        boolean expectedValue = false;
+
+        // when
+        boolean isLiked = gymLikeService.isLiked(userId, gymId);
+
+        //then
+        then(isLiked).equals(expectedValue);
+        then(gymLikeRepository).should().existsByGymLikePK_UserIdAndGymLikePK_GymId(anyLong(), anyLong());
+    }
+
+    private static GymLikeDto createGymLikeDto(GymLikePK gymLikePK) {
+        return GymLikeDto.from(GymLike.of(gymLikePK));
+    }
 }

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
@@ -1,4 +1,287 @@
 package org.fastcampus.oruryclient.gym.service;
 
-public class GymServiceTest {
+import org.fastcampus.orurycommon.error.code.GymErrorCode;
+import org.fastcampus.orurycommon.error.exception.BusinessException;
+import org.fastcampus.orurydomain.gym.db.model.Gym;
+import org.fastcampus.orurydomain.gym.db.repository.GymRepository;
+import org.fastcampus.orurydomain.gym.dto.GymDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GymServiceTest")
+@ActiveProfiles("test")
+class GymServiceTest {
+
+    private GymService gymService;
+    private GymRepository gymRepository;
+
+    @BeforeEach
+    void setUp() {
+        gymRepository = mock(GymRepository.class);
+        gymService = new GymService(gymRepository);
+    }
+
+    @Test
+    @DisplayName("존재하는 암장id가 들어오면, 정상적으로 GymDto를 반환한다.")
+    void should_RetrieveGymDtoById() {
+        //given
+        Long gymId = 1L;
+        Gym gym = createGym(gymId);
+
+        given(gymRepository.findById(gymId)).willReturn(Optional.of(gym));
+
+        GymDto expectedGymDto = GymDto.from(gym);
+
+        //when
+        GymDto gymDto = gymService.getGymDtoById(gymId);
+
+        //then
+        then(gymDto).equals(expectedGymDto);
+        then(gymRepository).should().findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 암장id가 들어오면, NOT_FOUND 예외를 반환한다.")
+    void two() {
+        //given
+        Long gymId = 1L;
+        Gym gym = createGym(gymId);
+
+        given(gymRepository.findById(gymId)).willReturn(Optional.empty());
+
+        GymDto expectedGymDto = GymDto.from(gym);
+
+        //when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> gymService.getGymDtoById(gymId));
+
+        then(exception.getStatus()).equals(GymErrorCode.NOT_FOUND.getStatus());
+        then(gymRepository).should().findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("검색어, 경도, 위도에 대해, 해당 검색어가 포함된 List<Gym>을 가까운 순으로 정렬해서 반환한다.")
+    void should_SortByDistanceAndRetrieveGymDtoList() {
+        //given
+        float currentLatitude = 10.111111f;
+        float currentLongitude = 10.111111f;
+        Gym middleGym = createGym(1L, "20.000001", "50.543210");
+        Gym mostFarGym = createGym(2L, "50.123456", "137.654321");
+        Gym mostNearGym = createGym(3L, "11.110111", "12.222222");
+        List<Gym> searchedGyms = List.of(middleGym, mostFarGym, mostNearGym);
+
+        given(gymRepository.findByNameContaining(anyString())).willReturn(searchedGyms);
+
+        List<GymDto> expectedGymDtos = List.of(
+                GymDto.from(mostNearGym),
+                GymDto.from(middleGym),
+                GymDto.from(mostFarGym)
+        );
+
+        //when
+        List<GymDto> gymDtos = gymService.getGymDtosBySearchWordOrderByDistanceAsc("", currentLatitude, currentLongitude);
+
+        //then
+        then(gymDtos).equals(expectedGymDtos);
+        then(gymRepository).should().findByNameContaining(anyString());
+    }
+
+    @Test
+    @DisplayName("검색어를 포함한 List<Gym>이 비어있어도, 빈 List를 반환한다.")
+    void when_NothingSearched_Then_RetrieveEmptyList() {
+        //given
+        given(gymRepository.findByNameContaining(anyString())).willReturn(List.of());
+
+        //when
+        List<GymDto> gymDtos = gymService.getGymDtosBySearchWordOrderByDistanceAsc("", 12.34f, 56.78f);
+
+        //then
+        then(gymDtos).equals(List.of());
+        then(gymRepository).should().findByNameContaining(anyString());
+    }
+
+    @Test
+    @DisplayName("현재 시간이 GymDto의 영업시간 사이에 있다면, true를 반환한다.")
+    void when_CurrentTimeIsBetweenBusinessHours_Then_ReturnTrue() {
+        //given
+        GymDto gymDto = createGymDto(
+                LocalTime.now().minusMinutes(1L),
+                LocalTime.now().plusMinutes(1L)
+        );
+
+        //when
+        boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
+
+        //then
+        then(doingBusiness).equals(true);
+    }
+
+    @Test
+    @DisplayName("현재 시간이 GymDto의 영업시간 전이라면, false를 반환한다.")
+    void when_CurrentTimeIsBeforeBusinessHours_Then_ReturnFalse() {
+        //given
+        GymDto gymDto = createGymDto(
+                LocalTime.now().plusMinutes(1L),
+                LocalTime.now().plusMinutes(2L)
+        );
+
+        //when
+        boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
+
+        //then
+        then(doingBusiness).equals(false);
+    }
+
+    @Test
+    @DisplayName("현재 시간이 GymDto의 영업시간 후이라면, false를 반환한다.")
+    void when_CurrentTimeIsAfterBusinessHours_Then_ReturnFalse() {
+        //given
+        GymDto gymDto = createGymDto(
+                LocalTime.now().minusMinutes(2L),
+                LocalTime.now().minusMinutes(1L)
+        );
+
+        //when
+        boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
+
+        //then
+        then(doingBusiness).equals(false);
+    }
+
+    @Test
+    @DisplayName("존재하는 gymId가 들어오면, 아무것도 하지 않는다.")
+    void when_IdOfExistingGym_Then_DoNothing() {
+        //given
+        Long gymId = 1L;
+        Gym gym = createGym(gymId);
+
+        given(gymRepository.findById(gymId)).willReturn(Optional.of(gym));
+
+        //when
+        assertDoesNotThrow(
+                () -> gymService.isValidate(gymId)
+        );
+
+        //then
+        then(gymRepository).should().findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 gymId가 들어오면, NOT_FOUND 예외를 반환한다.")
+    void when_IdOfNotExistingGym_Then_NotFoundException() {
+        //given
+        Long gymId = 1L;
+        Gym gym = createGym(gymId);
+
+        given(gymRepository.findById(gymId)).willReturn(Optional.empty());
+
+        //when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> gymService.isValidate(gymId)
+        );
+
+        //then
+        then(exception.getStatus()).equals(GymErrorCode.NOT_FOUND.getStatus());
+        then(gymRepository).should().findById(anyLong());
+    }
+
+    private static Gym createGym(Long id) {
+        return Gym.of(
+                id,
+                "gymName",
+                "gymKakaoId",
+                "gymRoadAddress",
+                "gymAddress",
+                4.5f,
+                12,
+                "gymImages",
+                "123.456",
+                "123.456",
+                "gymBrand",
+                "010-1234-5678",
+                "gymInstaLink",
+                "MONDAY",
+                "11:00-23:11",
+                "12:00-23:22",
+                "13:00-23:33",
+                "14:00-23:44",
+                "15:00-23:55",
+                "16:00-23:66",
+                "17:00-23:77",
+                "gymHomepageLink",
+                "gymRemark"
+        );
+    }
+
+    private static Gym createGym(Long id, String latitude, String longitude) {
+        return Gym.of(
+                id,
+                "gymName",
+                "gymKakaoId",
+                "gymRoadAddress",
+                "gymAddress",
+                4.5f,
+                12,
+                "gymImages",
+                latitude,
+                longitude,
+                "gymBrand",
+                "010-1234-5678",
+                "gymInstaLink",
+                "MONDAY",
+                "11:00-23:11",
+                "12:00-23:22",
+                "13:00-23:33",
+                "14:00-23:44",
+                "15:00-23:55",
+                "16:00-23:66",
+                "17:00-23:77",
+                "gymHomepageLink",
+                "gymRemark"
+        );
+    }
+
+    private static GymDto createGymDto(LocalTime openTime, LocalTime closeTime) {
+        return GymDto.of(
+                1L,
+                "더클라임 봉은사점",
+                "kakaoid",
+                "서울시 도로명주소",
+                "서울시 지번주소",
+                4.5f,
+                12,
+                "image.png",
+                "37.513709",
+                "127.062144",
+                "더클라임",
+                "01012345678",
+                "gymInstagramLink.com",
+                "MONDAY",
+                LocalDateTime.of(1999, 3, 1, 7, 30),
+                LocalDateTime.of(2024, 1, 23, 18, 32),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                "gymHomepageLink",
+                "gymRemark"
+        );
+    }
 }

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GymServiceTest")
+@DisplayName("[Service] 암장 테스트")
 @ActiveProfiles("test")
 class GymServiceTest {
 

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
@@ -42,7 +42,8 @@ class GymServiceTest {
         Long gymId = 1L;
         Gym gym = createGym(gymId);
 
-        given(gymRepository.findById(gymId)).willReturn(Optional.of(gym));
+        given(gymRepository.findById(gymId))
+                .willReturn(Optional.of(gym));
 
         GymDto expectedGymDto = GymDto.from(gym);
 
@@ -50,8 +51,10 @@ class GymServiceTest {
         GymDto gymDto = gymService.getGymDtoById(gymId);
 
         //then
-        then(gymDto).equals(expectedGymDto);
-        then(gymRepository).should().findById(anyLong());
+        then(gymDto)
+                .equals(expectedGymDto);
+        then(gymRepository).should()
+                .findById(anyLong());
     }
 
     @Test
@@ -61,7 +64,8 @@ class GymServiceTest {
         Long gymId = 1L;
         Gym gym = createGym(gymId);
 
-        given(gymRepository.findById(gymId)).willReturn(Optional.empty());
+        given(gymRepository.findById(gymId))
+                .willReturn(Optional.empty());
 
         GymDto expectedGymDto = GymDto.from(gym);
 
@@ -69,8 +73,10 @@ class GymServiceTest {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> gymService.getGymDtoById(gymId));
 
-        then(exception.getStatus()).equals(GymErrorCode.NOT_FOUND.getStatus());
-        then(gymRepository).should().findById(anyLong());
+        then(exception.getStatus())
+                .equals(GymErrorCode.NOT_FOUND.getStatus());
+        then(gymRepository).should()
+                .findById(anyLong());
     }
 
     @Test
@@ -79,12 +85,25 @@ class GymServiceTest {
         //given
         float currentLatitude = 10.111111f;
         float currentLongitude = 10.111111f;
-        Gym middleGym = createGym(1L, "20.000001", "50.543210");
-        Gym mostFarGym = createGym(2L, "50.123456", "137.654321");
-        Gym mostNearGym = createGym(3L, "11.110111", "12.222222");
+        Gym middleGym = createGym(
+                1L,
+                "20.000001",
+                "50.543210"
+        );
+        Gym mostFarGym = createGym(
+                2L,
+                "50.123456",
+                "137.654321"
+        );
+        Gym mostNearGym = createGym(
+                3L,
+                "11.110111",
+                "12.222222"
+        );
         List<Gym> searchedGyms = List.of(middleGym, mostFarGym, mostNearGym);
 
-        given(gymRepository.findByNameContaining(anyString())).willReturn(searchedGyms);
+        given(gymRepository.findByNameContaining(anyString()))
+                .willReturn(searchedGyms);
 
         List<GymDto> expectedGymDtos = List.of(
                 GymDto.from(mostNearGym),
@@ -96,22 +115,28 @@ class GymServiceTest {
         List<GymDto> gymDtos = gymService.getGymDtosBySearchWordOrderByDistanceAsc("", currentLatitude, currentLongitude);
 
         //then
-        then(gymDtos).equals(expectedGymDtos);
-        then(gymRepository).should().findByNameContaining(anyString());
+        then(gymDtos)
+                .equals(expectedGymDtos);
+        then(gymRepository).should()
+                .findByNameContaining(anyString());
     }
 
     @Test
     @DisplayName("검색어를 포함한 List<Gym>이 비어있어도, 빈 List를 반환한다.")
     void when_NothingSearched_Then_RetrieveEmptyList() {
         //given
-        given(gymRepository.findByNameContaining(anyString())).willReturn(List.of());
+        given(gymRepository.findByNameContaining(anyString()))
+                .willReturn(List.of());
+        List<GymDto> expectedgymDtos = List.of();
 
         //when
         List<GymDto> gymDtos = gymService.getGymDtosBySearchWordOrderByDistanceAsc("", 12.34f, 56.78f);
 
         //then
-        then(gymDtos).equals(List.of());
-        then(gymRepository).should().findByNameContaining(anyString());
+        then(gymDtos)
+                .equals(expectedgymDtos);
+        then(gymRepository).should()
+                .findByNameContaining(anyString());
     }
 
     @Test
@@ -127,7 +152,8 @@ class GymServiceTest {
         boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
 
         //then
-        then(doingBusiness).equals(true);
+        then(doingBusiness)
+                .equals(true);
     }
 
     @Test
@@ -143,7 +169,8 @@ class GymServiceTest {
         boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
 
         //then
-        then(doingBusiness).equals(false);
+        then(doingBusiness)
+                .equals(false);
     }
 
     @Test
@@ -159,7 +186,8 @@ class GymServiceTest {
         boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
 
         //then
-        then(doingBusiness).equals(false);
+        then(doingBusiness)
+                .equals(false);
     }
 
     @Test
@@ -169,7 +197,8 @@ class GymServiceTest {
         Long gymId = 1L;
         Gym gym = createGym(gymId);
 
-        given(gymRepository.findById(gymId)).willReturn(Optional.of(gym));
+        given(gymRepository.findById(gymId))
+                .willReturn(Optional.of(gym));
 
         //when
         assertDoesNotThrow(
@@ -177,7 +206,8 @@ class GymServiceTest {
         );
 
         //then
-        then(gymRepository).should().findById(anyLong());
+        then(gymRepository).should()
+                .findById(anyLong());
     }
 
     @Test
@@ -187,7 +217,8 @@ class GymServiceTest {
         Long gymId = 1L;
         Gym gym = createGym(gymId);
 
-        given(gymRepository.findById(gymId)).willReturn(Optional.empty());
+        given(gymRepository.findById(gymId))
+                .willReturn(Optional.empty());
 
         //when
         BusinessException exception = assertThrows(BusinessException.class,
@@ -195,8 +226,10 @@ class GymServiceTest {
         );
 
         //then
-        then(exception.getStatus()).equals(GymErrorCode.NOT_FOUND.getStatus());
-        then(gymRepository).should().findById(anyLong());
+        then(exception.getStatus())
+                .equals(GymErrorCode.NOT_FOUND.getStatus());
+        then(gymRepository).should()
+                .findById(anyLong());
     }
 
     private static Gym createGym(Long id) {


### PR DESCRIPTION
## 개요
- 테스트하고자 하는 메서드의 접근제어자를 private으로 설정하면, 해당 메서드는 테스트코드에서도 접근이 불가능합니다.
- GymService의 getDistance()가 그러한데, 
해당 메서드를 호출하는 getGymDtosBySearchWordOrderByDistanceAsc() 메서드의 테스트코드만 잘 작성해도 커버리지 100% 달성하는 것을 확인했습니다.
- 따라서 앞으로는, private 접근제어자를 가진 메서드를, 테스트코드만을 위해 public으로 변경하지 않아도 될 듯 합니다. (테스트코드만을 위한 코드가 되지는 않아야 하기 때문...?)
- GymService, GymLikeService 모두 Coverage 100% 달성했습니다~
<img width="1294" alt="image" src="https://github.com/Kernel360/f1-Orury-Backend/assets/147565215/e35cf573-79ed-429b-8cb7-8ddd4075f931">
<img width="1077" alt="image" src="https://github.com/Kernel360/f1-Orury-Backend/assets/147565215/0498b0d7-b7dd-4722-9d4f-b746cb9ba757">

closed #178

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
