### PR TITLE
Fix : swagger docs 접근 허용

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilter.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilter.java
@@ -46,7 +46,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludePath = {"/auth", "/login", "/swagger-ui", "/swagger-resources"};
+        String[] excludePath = {"/auth", "/login", "/swagger-ui", "/v3/api-docs"};
         String path = request.getRequestURI();
         return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }

--- a/orury-common/src/main/java/org/fastcampus/orurycommon/log/LoggerFilter.java
+++ b/orury-common/src/main/java/org/fastcampus/orurycommon/log/LoggerFilter.java
@@ -11,6 +11,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @Slf4j
 @Component
@@ -69,5 +70,12 @@ public class LoggerFilter extends OncePerRequestFilter {
 
 
         res.copyBodyToResponse();
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String[] excludePath = {"/swagger-ui", "/v3/api-docs"};
+        String path = request.getRequestURI();
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }
 }


### PR DESCRIPTION
## 개요
- 기존: 유효한 액세스 토큰 아니라고 응답이 나오나, 의도한 바 대로면 swagger api는 JwtTokenFilter에서 무시해야 합니다.
- 해결
    - api 요청을 확인해 보니, 아래 uri들이 요청되고 있었습니다.
        /swagger-ui/index.html
        /swagger-ui/swagger-ui.css
        /swagger-ui/swagger-ui-standalone-preset.js
        /swagger-ui/index.css
        /swagger-ui/swagger-ui-bundle.js
        /swagger-ui/swagger-initializer.js
        /swagger-ui/favicon-32x32.png
        /v3/api-docs/swagger-config
        /v3/api-docs
    - 그래서 “/swagger-ui”, “/v3/api-docs”를 shouldNotFilter의 excludePath에 설정해준 것으로 해결했습니다.
- 추가로, LoggerFilter의 로깅에서, swagger 접속에 과도하게 많은 로그를 출력해서 해당 로깅은 배제시켰습니다.

closed #184

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
