### PR TITLE
Test : JwtTokenFilter & JwtTokenProvider 테스트코드

### DIFF
--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
@@ -1,0 +1,150 @@
+package org.fastcampus.oruryclient.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.fastcampus.orurycommon.error.code.TokenErrorCode;
+import org.fastcampus.orurycommon.error.exception.AuthException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+class JwtTokenFilterTest {
+
+    private JwtTokenFilter jwtTokenFilter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private FilterChain filterChain;
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    public void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = mock(FilterChain.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+
+        jwtTokenFilter = new JwtTokenFilter(jwtTokenProvider);
+    }
+
+    @DisplayName("JwtTokenFilter의 대상이고 jwtToken Exception이 발생하지 않으면, 정상적으로 doFilterInternal()을 수행한다.")
+    @Test
+    void temp1() throws ServletException, IOException {
+        // given
+        request.setRequestURI("/api/v1/posts/1");
+
+        // when
+        jwtTokenFilter.doFilter(request, response, filterChain);
+
+        // then
+        then(filterChain).should()
+                .doFilter(any(), any());
+
+        then(jwtTokenProvider).should()
+                .getTokenFromRequest(any());
+        then(jwtTokenProvider).should()
+                .getAuthenticationFromAccessToken(any());
+    }
+
+    @DisplayName("request 헤더에 유효한 토큰이 없으면, 필터를 거치지 않는다.")
+    @Test
+    void temp2() throws ServletException, IOException {
+        // given
+        request.setRequestURI("/api/v1/comments/2");
+
+        given(jwtTokenProvider.getTokenFromRequest(request))
+                .willThrow(new AuthException(TokenErrorCode.INVALID_ACCESS_TOKEN));
+
+        // when
+        jwtTokenFilter.doFilter(request, response, filterChain);
+
+        // then
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), response.getStatus());
+
+        then(filterChain).should(never())
+                .doFilter(request, response);
+
+        then(jwtTokenProvider).should()
+                .getTokenFromRequest(any());
+        then(jwtTokenProvider).should(never())
+                .getAuthenticationFromAccessToken(any());
+    }
+
+    @Test
+    void temp3() throws ServletException, IOException {
+        // given
+        request.setRequestURI("/api/v1/reviews/3");
+
+        given(jwtTokenProvider.getAuthenticationFromAccessToken(any()))
+                .willThrow(new AuthException(TokenErrorCode.INVALID_ACCESS_TOKEN));
+
+        // when
+        jwtTokenFilter.doFilter(request, response, filterChain);
+
+        // then
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), response.getStatus());
+
+        then(filterChain).should(never())
+                .doFilter(request, response);
+
+        then(jwtTokenProvider).should()
+                .getTokenFromRequest(any());
+        then(jwtTokenProvider).should()
+                .getAuthenticationFromAccessToken(any());
+    }
+
+    @Test
+    void temp4() throws ServletException, IOException {
+        // given
+        request.setRequestURI("/api/v1/gyms/4");
+
+        given(jwtTokenProvider.getAuthenticationFromAccessToken(any()))
+                .willThrow(new AuthException(TokenErrorCode.EXPIRED_ACCESS_TOKEN));
+
+        // when
+        jwtTokenFilter.doFilter(request, response, filterChain);
+
+        // then
+        assertEquals(TokenErrorCode.EXPIRED_ACCESS_TOKEN.getStatus(), response.getStatus());
+
+        then(filterChain).should(never())
+                .doFilter(request, response);
+
+        then(jwtTokenProvider).should()
+                .getTokenFromRequest(any());
+        then(jwtTokenProvider).should()
+                .getAuthenticationFromAccessToken(any());
+    }
+
+    @DisplayName("JwtTokenFilter의 대상 request가 아니라면, 정상적으로 shouldNotFilter()을 수행한다.")
+    @Test
+    void when_ExcludePath_Then_ShouldNotFilter() throws ServletException, IOException {
+        // given
+        String[] excludePath = {"/api/v1/auth", "/swagger-ui", "/v3/api-docs", "/favicon.ico"};
+
+        for (String path : excludePath) {
+            request.setRequestURI(path + "/temp-path");
+
+            // when
+            jwtTokenFilter.doFilter(request, response, filterChain);
+        }
+
+        // then
+        then(filterChain).should(times(excludePath.length))
+                .doFilter(any(), any());
+
+        then(jwtTokenProvider).should(never())
+                .getTokenFromRequest(any());
+        then(jwtTokenProvider).should(never())
+                .getAuthenticationFromAccessToken(any());
+    }
+}

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
@@ -61,7 +61,7 @@ class JwtTokenFilterTest {
                 .getAuthenticationFromAccessToken(any());
     }
 
-    @DisplayName("request 헤더에 유효한 토큰이 없으면, 필터를 거치지 않는다.")
+    @DisplayName("getTokenFromRequest에서 InvalidException이 발생하면, 필터를 거치지 않는다.")
     @Test
     void when_InvalidExceptionByGetTokenFromRequest_Then_DoNotPassFilter() throws ServletException, IOException {
         // given
@@ -85,6 +85,7 @@ class JwtTokenFilterTest {
                 .getAuthenticationFromAccessToken(any());
     }
 
+    @DisplayName("getAuthenticationFromAccessToken에서 InvalidException이 발생하면, 필터를 거치지 않는다.")
     @Test
     void when_InvalidExceptionByGetAuthenticationFromAccessToken_Then_DoNotPassFilter() throws ServletException, IOException {
         // given
@@ -108,6 +109,7 @@ class JwtTokenFilterTest {
                 .getAuthenticationFromAccessToken(any());
     }
 
+    @DisplayName("getAuthenticationFromAccessToken에서 ExpiredException이 발생하면, 필터를 거치지 않는다.")
     @Test
     void when_ExpiredExceptionByGetAuthenticationFromAccessToken_Then_DoNotPassFilter() throws ServletException, IOException {
         // given

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
@@ -7,8 +7,11 @@ import org.fastcampus.orurycommon.error.exception.AuthException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
 
@@ -18,6 +21,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtTokenFilter 테스트")
+@ActiveProfiles("test")
 class JwtTokenFilterTest {
 
     private JwtTokenFilter jwtTokenFilter;
@@ -38,7 +44,7 @@ class JwtTokenFilterTest {
 
     @DisplayName("JwtTokenFilter의 대상이고 jwtToken Exception이 발생하지 않으면, 정상적으로 doFilterInternal()을 수행한다.")
     @Test
-    void temp1() throws ServletException, IOException {
+    void should_DoFilterInternalSuccessfully() throws ServletException, IOException {
         // given
         request.setRequestURI("/api/v1/posts/1");
 
@@ -57,7 +63,7 @@ class JwtTokenFilterTest {
 
     @DisplayName("request 헤더에 유효한 토큰이 없으면, 필터를 거치지 않는다.")
     @Test
-    void temp2() throws ServletException, IOException {
+    void when_InvalidExceptionByGetTokenFromRequest_Then_DoNotPassFilter() throws ServletException, IOException {
         // given
         request.setRequestURI("/api/v1/comments/2");
 
@@ -80,7 +86,7 @@ class JwtTokenFilterTest {
     }
 
     @Test
-    void temp3() throws ServletException, IOException {
+    void when_InvalidExceptionByGetAuthenticationFromAccessToken_Then_DoNotPassFilter() throws ServletException, IOException {
         // given
         request.setRequestURI("/api/v1/reviews/3");
 
@@ -103,7 +109,7 @@ class JwtTokenFilterTest {
     }
 
     @Test
-    void temp4() throws ServletException, IOException {
+    void when_ExpiredExceptionByGetAuthenticationFromAccessToken_Then_DoNotPassFilter() throws ServletException, IOException {
         // given
         request.setRequestURI("/api/v1/gyms/4");
 
@@ -127,7 +133,7 @@ class JwtTokenFilterTest {
 
     @DisplayName("JwtTokenFilter의 대상 request가 아니라면, 정상적으로 shouldNotFilter()을 수행한다.")
     @Test
-    void when_ExcludePath_Then_ShouldNotFilter() throws ServletException, IOException {
+    void when_ExcludePath_Then_should_ShouldNotFilterSuccessfully() throws ServletException, IOException {
         // given
         String[] excludePath = {"/api/v1/auth", "/swagger-ui", "/v3/api-docs", "/favicon.ico"};
 

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProviderTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProviderTest.java
@@ -52,14 +52,14 @@ class JwtTokenProviderTest {
 
     @BeforeEach
     public void setUp() {
-        String secret = "=============================================JwtTokenSecretForOruryTestCode=============================================";
+        secret = "=============================================JwtTokenSecretForOruryTestCode=============================================";
         refreshTokenRepository = mock(RefreshTokenRepository.class);
 
         jwtTokenProvider = new JwtTokenProvider(secret, refreshTokenRepository);
     }
 
-    @Test
     @DisplayName("HttpServletRequest의 Authorization 헤더가 들어가있으면, Prefix(Bearer )를 제거한 jwt 토큰을 반환해야 한다.")
+    @Test
     void should_ReturnAccessTokenTokenWithoutPrefix() {
         // given
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -77,8 +77,8 @@ class JwtTokenProviderTest {
         assertEquals(expectedToken, actualToken);
     }
 
-    @Test
     @DisplayName("Authorization 헤더에 담긴 토큰이 없으면, InvalidAccessToken 예외를 발생시킨다.")
+    @Test
     void when_NullValueInAuthorizationHeader_Then_InvalidAccessTokenException() {
         // given
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -93,8 +93,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("Authorization 헤더에 담긴 토큰 prefix가 \"Bearer \"가 아니면, InvalidAccessToken 예외를 발생시킨다.")
+    @Test
     void when_invalidPrefixAccessToken_Then_InvalidAccessTokenException() {
         // given
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -111,8 +111,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("만료되지 않고 유효한 형식의 액세스토큰이 들어오면, 액세스토큰으로부터 생성한 인증객체를 정상적으로 반환한다.")
+    @Test
     void should_RetrieveAuthenticationFromNormalAccessToken() {
         // given
         String accessToken = VALID_ACCESS_TOKEN;
@@ -138,8 +138,8 @@ class JwtTokenProviderTest {
         );
     }
 
-    @Test
     @DisplayName("유효하지 않은 형식의 액세스토큰이 들어오면, InvalidAccessToken 예외를 반환한다.")
+    @Test
     void when_MalFormedAccessToken_Then_InvalidAccessTokenException() {
         // given
         String accessToken = VALID_ACCESS_TOKEN.substring(0, 20);
@@ -151,8 +151,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("Jwt토큰이 아닌 값이 들어오면, InvalidAccessToken 예외를 반환한다.")
+    @Test
     void when_IllegalArgument_Then_InvalidAccessTokenException() {
         // given
         String accessToken = "IamNOTjwtTOKEN";
@@ -164,8 +164,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("만료된 액세스토큰이 들어오면, ExpiredAccessToken 예외를 반환한다.")
+    @Test
     void when_ExpiredAccessToken_Then_ExpiredAccessTokenException() {
         // given
         String accessToken = EXPIRED_ACCESS_TOKEN;
@@ -177,8 +177,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.EXPIRED_ACCESS_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("만료되지 않고 유효한 형식의 리프레쉬토큰으로부터 생성한 인증객체를 정상적으로 반환한다.")
+    @Test
     void should_RetrieveAuthenticationFromNormalRefreshToken() {
         // given
         String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
@@ -194,8 +194,8 @@ class JwtTokenProviderTest {
                 .findByValue(anyString());
     }
 
-    @Test
     @DisplayName("리프레쉬토큰이 null로 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    @Test
     void when_NullRefreshToken_Then_InvalidRefreshTokenException() {
         // given
         String refreshToken = null;
@@ -207,8 +207,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("리프레쉬토큰 prefix가 \"Bearer \"가 아니면, InvalidRefreshToken 예외를 반환한다.")
+    @Test
     void when_invalidPrefixRefreshToken_Then_InvalidRefreshTokenException() {
         // given
         String refreshToken = "Orury " + VALID_REFRESH_TOKEN;
@@ -220,8 +220,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("유효하지 않은 형식의 리프레쉬토큰이 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    @Test
     void when_MalFormedRefreshToken_Then_InvalidRefreshTokenException() {
         // given
         String refreshToken = "Bearer " + VALID_REFRESH_TOKEN.substring(0, 20);
@@ -233,8 +233,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("Jwt토큰이 아닌 값이 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    @Test
     void when_IllegalArgument_Then_InvalidRefreshTokenException() {
         // given
         String refreshToken = "Bearer " + "IamNOTjwtTOKEN";
@@ -246,8 +246,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("만료된 리프레쉬토큰이 들어오면, ExpiredRefreshToken 예외를 반환한다.")
+    @Test
     void when_ExpiredRefreshToken_Then_ExpiredRefreshTokenException() {
         // given
         String refreshToken = "Bearer " + EXPIRED_REFRESH_TOKEN;
@@ -259,8 +259,8 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.EXPIRED_REFRESH_TOKEN.getStatus(), exception.getStatus());
     }
 
-    @Test
     @DisplayName("갱신되기 전의 리프레시토큰이 들어오면, ExpiredRefreshToken 예외를 반환한다.")
+    @Test
     void when_RefreshTokenBeforeReissue_Then_ExpiredRefreshTokenException() {
         // given
         String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
@@ -278,8 +278,8 @@ class JwtTokenProviderTest {
                 .findByValue(anyString());
     }
 
-    @Test
     @DisplayName("id와 email을 받으면, 액세스토큰과 리프레시토큰을 생성하고 저장하여 돌려준다.")
+    @Test
     void when_IdAndEmail_Then_CreateAndSaveJwtTokens() {
         // given
         Long userId = 2L;

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProviderTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,295 @@
+package org.fastcampus.oruryclient.auth.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.fastcampus.oruryclient.global.constants.Constants;
+import org.fastcampus.orurycommon.error.code.TokenErrorCode;
+import org.fastcampus.orurycommon.error.exception.AuthException;
+import org.fastcampus.orurydomain.auth.db.model.RefreshToken;
+import org.fastcampus.orurydomain.auth.db.repository.RefreshTokenRepository;
+import org.fastcampus.orurydomain.user.dto.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtTokenProvider 테스트")
+@ActiveProfiles("test")
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+    private String secret;
+    private RefreshTokenRepository refreshTokenRepository;
+
+    // Jwt토큰 유저 정보
+    private final Long TOKEN_USER_ID = 1L;
+    private final String TOKEN_USER_EMAIL = "email@orury.com";
+
+    // 유효한 토큰
+    private final String VALID_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNDUyLCJleHAiOjIzMTEwNDM0NTJ9.LtE-2BG5o-EO-SelasvEdyKNXMWNJaSagbBhcpHjxp0";
+    private final String VALID_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNDUyLCJleHAiOjI5MTU4NDM0NTJ9.AUXxm1cVPW3eOw2QCUTgU5QciyoL9w3oHyHkRhiQF8M";
+
+    // 만료된 토큰
+    private final String EXPIRED_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNzE2LCJleHAiOjE3MDYyNDM3NzZ9.nTKrQ7HxWiS9dG0WixQ6F578ugkSfN2TosXUnHr_fpc";
+    private final String EXPIRED_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNzE2LCJleHAiOjE3MDYyNDM4MzZ9.v8AKma4QS3zCg1UzejUPf-uuY5BpwM7OiACNljY-QxM";
+
+    @BeforeEach
+    public void setUp() {
+        String secret = "=============================================JwtTokenSecretForOruryTestCode=============================================";
+        refreshTokenRepository = mock(RefreshTokenRepository.class);
+
+        jwtTokenProvider = new JwtTokenProvider(secret, refreshTokenRepository);
+    }
+
+    @Test
+    @DisplayName("HttpServletRequest의 Authorization 헤더가 들어가있으면, Prefix(Bearer )를 제거한 jwt 토큰을 반환해야 한다.")
+    void should_ReturnAccessTokenTokenWithoutPrefix() {
+        // given
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+        String accessTokenHeader = "Bearer " + VALID_ACCESS_TOKEN;
+        String expectedToken = VALID_ACCESS_TOKEN;
+
+        given(mockRequest.getHeader("Authorization"))
+                .willReturn(accessTokenHeader);
+
+        // when
+        String actualToken = jwtTokenProvider.getTokenFromRequest(mockRequest);
+
+        // then
+        assertEquals(expectedToken, actualToken);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더에 담긴 토큰이 없으면, InvalidAccessToken 예외를 발생시킨다.")
+    void when_NullValueInAuthorizationHeader_Then_InvalidAccessTokenException() {
+        // given
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+        given(mockRequest.getHeader("Authorization"))
+                .willReturn(null);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getTokenFromRequest(mockRequest));
+
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더에 담긴 토큰 prefix가 \"Bearer \"가 아니면, InvalidAccessToken 예외를 발생시킨다.")
+    void when_invalidPrefixAccessToken_Then_InvalidAccessTokenException() {
+        // given
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+        String accessTokenHeader = "Orury " + VALID_ACCESS_TOKEN;
+
+        given(mockRequest.getHeader("Authorization"))
+                .willReturn(accessTokenHeader);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getTokenFromRequest(mockRequest));
+
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("만료되지 않고 유효한 형식의 액세스토큰이 들어오면, 액세스토큰으로부터 생성한 인증객체를 정상적으로 반환한다.")
+    void should_RetrieveAuthenticationFromNormalAccessToken() {
+        // given
+        String accessToken = VALID_ACCESS_TOKEN;
+
+        Long userId = TOKEN_USER_ID;
+        String userEmail = TOKEN_USER_EMAIL;
+
+        UserPrincipal expectedPrincipal = UserPrincipal.fromToken(
+                userId,
+                userEmail,
+                Constants.ROLE_USER.getMessage()
+        );
+        String expectedCredentials = "";
+        List<SimpleGrantedAuthority> expectedAuthorities = Collections.singletonList(new SimpleGrantedAuthority(Constants.ROLE_USER.getMessage()));
+
+        // when
+        Authentication authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
+
+        // then
+        assertEquals(
+                new UsernamePasswordAuthenticationToken(expectedPrincipal, expectedCredentials, expectedAuthorities),
+                authentication
+        );
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 형식의 액세스토큰이 들어오면, InvalidAccessToken 예외를 반환한다.")
+    void when_MalFormedAccessToken_Then_InvalidAccessTokenException() {
+        // given
+        String accessToken = VALID_ACCESS_TOKEN.substring(0, 20);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getAuthenticationFromAccessToken(accessToken));
+
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("Jwt토큰이 아닌 값이 들어오면, InvalidAccessToken 예외를 반환한다.")
+    void when_IllegalArgument_Then_InvalidAccessTokenException() {
+        // given
+        String accessToken = "IamNOTjwtTOKEN";
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getAuthenticationFromAccessToken(accessToken));
+
+        assertEquals(TokenErrorCode.INVALID_ACCESS_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("만료된 액세스토큰이 들어오면, ExpiredAccessToken 예외를 반환한다.")
+    void when_ExpiredAccessToken_Then_ExpiredAccessTokenException() {
+        // given
+        String accessToken = EXPIRED_ACCESS_TOKEN;
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getAuthenticationFromAccessToken(accessToken));
+
+        assertEquals(TokenErrorCode.EXPIRED_ACCESS_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("만료되지 않고 유효한 형식의 리프레쉬토큰으로부터 생성한 인증객체를 정상적으로 반환한다.")
+    void should_RetrieveAuthenticationFromNormalRefreshToken() {
+        // given
+        String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
+
+        given(refreshTokenRepository.findByValue(anyString()))
+                .willReturn(Optional.of(mock(RefreshToken.class)));
+
+        // when
+        jwtTokenProvider.reissueJwtTokens(refreshToken);
+
+        // then
+        then(refreshTokenRepository).should()
+                .findByValue(anyString());
+    }
+
+    @Test
+    @DisplayName("리프레쉬토큰이 null로 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    void when_NullRefreshToken_Then_InvalidRefreshTokenException() {
+        // given
+        String refreshToken = null;
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("리프레쉬토큰 prefix가 \"Bearer \"가 아니면, InvalidRefreshToken 예외를 반환한다.")
+    void when_invalidPrefixRefreshToken_Then_InvalidRefreshTokenException() {
+        // given
+        String refreshToken = "Orury " + VALID_REFRESH_TOKEN;
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 형식의 리프레쉬토큰이 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    void when_MalFormedRefreshToken_Then_InvalidRefreshTokenException() {
+        // given
+        String refreshToken = "Bearer " + VALID_REFRESH_TOKEN.substring(0, 20);
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("Jwt토큰이 아닌 값이 들어오면, InvalidRefreshToken 예외를 반환한다.")
+    void when_IllegalArgument_Then_InvalidRefreshTokenException() {
+        // given
+        String refreshToken = "Bearer " + "IamNOTjwtTOKEN";
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.INVALID_REFRESH_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("만료된 리프레쉬토큰이 들어오면, ExpiredRefreshToken 예외를 반환한다.")
+    void when_ExpiredRefreshToken_Then_ExpiredRefreshTokenException() {
+        // given
+        String refreshToken = "Bearer " + EXPIRED_REFRESH_TOKEN;
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.EXPIRED_REFRESH_TOKEN.getStatus(), exception.getStatus());
+    }
+
+    @Test
+    @DisplayName("갱신되기 전의 리프레시토큰이 들어오면, ExpiredRefreshToken 예외를 반환한다.")
+    void when_RefreshTokenBeforeReissue_Then_ExpiredRefreshTokenException() {
+        // given
+        String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
+
+        given(refreshTokenRepository.findByValue(anyString()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.reissueJwtTokens(refreshToken));
+
+        assertEquals(TokenErrorCode.EXPIRED_REFRESH_TOKEN.getStatus(), exception.getStatus());
+
+        then(refreshTokenRepository).should()
+                .findByValue(anyString());
+    }
+
+    @Test
+    @DisplayName("id와 email을 받으면, 액세스토큰과 리프레시토큰을 생성하고 저장하여 돌려준다.")
+    void when_IdAndEmail_Then_CreateAndSaveJwtTokens() {
+        // given
+        Long userId = 2L;
+        String userEmail = "orury2@orury.com";
+
+        // when
+        jwtTokenProvider.issueJwtTokens(userId, userEmail);
+
+        // then
+        then(refreshTokenRepository).should()
+                .save(any());
+    }
+}


### PR DESCRIPTION
## 개요
### JwtTokenFilterTest
- then(filterChain).should().dofilter(~) 을 통해, JwtTokenFilter을 거치는지에 대한 유무를 검증했고,
- doFilterInternal()에 있는 jwtTokenProvider의 메서드를 수행하는지 유무에 따라, 
doFilterInternal()을 수행하는지에 대한 유무를 검증했습니다
### JwtTokenProviderTest
- @Value를 테스트코드에서는 활용할 수 없기 때문에, 테스트코드용 (오픈 가능한) Secret을 바탕으로 JwtTokenProvider을 생성합니다.
- 상단에 명시된 토큰들은, 유저 정보(id=1L / email="email@orury.com")와 테스트코드용 Secret으로 생성되어, 테스트코드에서 parsing 가능한 Jwt토큰들입니다.
- private 접근제어자인 메서드(parseToken(), createJwtToken())는 다른 메서드에서의 호출만으로도 충분한 검증이 된다는 권태관멘토님의 멘토링으로, 따로 작성하지는 않았습니다.

<img width="993" alt="image" src="https://github.com/Kernel360/f1-Orury-Backend/assets/147565215/697fdd32-3a13-4663-9939-832d183b0272">

closed #193

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
