### PR TITLE
Refactor : 작업환경 (dev, prod)에 따른 application.yml 분리

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/global/config/DataSourceConfig.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/global/config/DataSourceConfig.java
@@ -1,62 +1,64 @@
-//package org.fastcampus.oruryclient.global.config;
-//
-//import com.zaxxer.hikari.HikariDataSource;
-//
-//import org.springframework.boot.context.properties.ConfigurationProperties;
-//import org.springframework.boot.jdbc.DataSourceBuilder;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.context.annotation.DependsOn;
-//import org.springframework.context.annotation.Primary;
-//import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-//import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
-//
-//import java.util.HashMap;
-//
-//import javax.sql.DataSource;
-//
-//import lombok.RequiredArgsConstructor;
-//
-//@Configuration
-//@RequiredArgsConstructor
-//@EnableJpaRepositories
-//public class DataSourceConfig {
-//
-//    // Write replica 정보로 만든 DataSource
-//    @Bean
-//    @ConfigurationProperties(prefix = "spring.datasource.write")
-//    public DataSource writeDataSource() {
-//        return DataSourceBuilder.create().type(HikariDataSource.class).build();
-//    }
-//
-//    // Read replica 정보로 만든 DataSource
-//    @Bean
-//    @ConfigurationProperties(prefix = "spring.datasource.read")
-//    public DataSource readDataSource() {
-//        return DataSourceBuilder.create().type(HikariDataSource.class).build();
-//    }
-//
-//    // 읽기 모드인지 여부로 DataSource를 분기 처리
-//    @Bean
-//    @DependsOn({"writeDataSource", "readDataSource"})
-//    public DataSource routeDataSource() {
-//        DataSourceRouter dataSourceRouter = new DataSourceRouter();
-//        DataSource writeDataSource = writeDataSource();
-//        DataSource readDataSource = readDataSource();
-//
-//        HashMap<Object, Object> dataSourceMap = new HashMap<>();
-//        dataSourceMap.put("write", writeDataSource);
-//        dataSourceMap.put("read", readDataSource);
-//        dataSourceRouter.setTargetDataSources(dataSourceMap);
-//        dataSourceRouter.setDefaultTargetDataSource(writeDataSource);
-//        return dataSourceRouter;
-//    }
-//
-//    @Bean
-//    @Primary
-//    @DependsOn({"routeDataSource"})
-//    public DataSource dataSource() {
-//        return new LazyConnectionDataSourceProxy(routeDataSource());
-//    }
-//
-//}
+package org.fastcampus.oruryclient.global.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import java.util.HashMap;
+
+import javax.sql.DataSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@Profile("prod")
+@RequiredArgsConstructor
+@EnableJpaRepositories
+public class DataSourceConfig {
+
+    // Write replica 정보로 만든 DataSource
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.write")
+    public DataSource writeDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    // Read replica 정보로 만든 DataSource
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.read")
+    public DataSource readDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    // 읽기 모드인지 여부로 DataSource를 분기 처리
+    @Bean
+    @DependsOn({"writeDataSource", "readDataSource"})
+    public DataSource routeDataSource() {
+        DataSourceRouter dataSourceRouter = new DataSourceRouter();
+        DataSource writeDataSource = writeDataSource();
+        DataSource readDataSource = readDataSource();
+
+        HashMap<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("write", writeDataSource);
+        dataSourceMap.put("read", readDataSource);
+        dataSourceRouter.setTargetDataSources(dataSourceMap);
+        dataSourceRouter.setDefaultTargetDataSource(writeDataSource);
+        return dataSourceRouter;
+    }
+
+    @Bean
+    @Primary
+    @DependsOn({"routeDataSource"})
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(routeDataSource());
+    }
+
+}

--- a/orury-client/src/main/resources/application-dev.yml
+++ b/orury-client/src/main/resources/application-dev.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ENC(+jNy+HRl5S5QeokxoLB89WTqqqa7EGm73Cpm2N4KXnu1yH3puewQxOUDussQQ9Qd)
+    username: ENC(ICwwkDRBtwGBxA6nGngL8g==)
+    password: ENC(HnXBRmSMLrFNxOsi9z6Iz+9nuM5BBLw2)

--- a/orury-client/src/main/resources/application-prod.yml
+++ b/orury-client/src/main/resources/application-prod.yml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    read:
+      jdbc-url: ENC(KkrDs/i2Asal3Qe2/GRo7vBh3Jdu3ozFVNy6sQzXYwKLScBRkm4jB4uWWCBF+rm/2t2XWE67sKRNXyL5fOChWLZ3hmp6KsMo4JSGjwXG8lzcStqVPMQ8jRq+cjaEALI4)
+      username: ENC(VUKxrYEb2eEVncT0XD7eeg==)
+      password: ENC(cGqwrzSfPJ96ZWhzjecvMoL80gulmH1r)
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    write:
+      jdbc-url: ENC(nYHDbyPX77wt52BMec5vJQLAWDcuiHS06QrV34A4AoEjrCnmNAmWNO/x0FUvNmvRhCPhaPkS1z9bhK7lyRVKocHukRjc5jwbf0XiceDDO2OtxDAfSPTvZg==)
+      username: ENC(VUKxrYEb2eEVncT0XD7eeg==)
+      password: ENC(cGqwrzSfPJ96ZWhzjecvMoL80gulmH1r)
+      driver-class-name: com.mysql.cj.jdbc.Driver

--- a/orury-client/src/main/resources/application.yml
+++ b/orury-client/src/main/resources/application.yml
@@ -13,28 +13,17 @@ springdoc:
   show-actuator: true
 
 spring:
+  profiles:
+    default: dev
   mvc:
     cors:
       allowed-origins: "*"
       allowed-methods: "GET, POST, PUT, DELETE"
   application.name: orury-client
   datasource:
-    #    url: ${LOCAL_DB_NAME}
-    url: ENC(+jNy+HRl5S5QeokxoLB89WTqqqa7EGm73Cpm2N4KXnu1yH3puewQxOUDussQQ9Qd)
-    #    username: ${LOCAL_DB_USER_NAME}
-    username: ENC(ICwwkDRBtwGBxA6nGngL8g==)
-    #    password: ${LOCAL_DB_USER_PASSWORD}
-    password: ENC(HnXBRmSMLrFNxOsi9z6Iz+9nuM5BBLw2)
-    #    read:
-    #      jdbc-url: ENC(KkrDs/i2Asal3Qe2/GRo7vBh3Jdu3ozFVNy6sQzXYwKLScBRkm4jB4uWWCBF+rm/2t2XWE67sKRNXyL5fOChWLZ3hmp6KsMo4JSGjwXG8lzcStqVPMQ8jRq+cjaEALI4)
-    #      username: ENC(VUKxrYEb2eEVncT0XD7eeg==)
-    #      password: ENC(cGqwrzSfPJ96ZWhzjecvMoL80gulmH1r)
-    #      driver-class-name: com.mysql.cj.jdbc.Driver
-    #    write:
-    #      jdbc-url: ENC(nYHDbyPX77wt52BMec5vJQLAWDcuiHS06QrV34A4AoEjrCnmNAmWNO/x0FUvNmvRhCPhaPkS1z9bhK7lyRVKocHukRjc5jwbf0XiceDDO2OtxDAfSPTvZg==)
-    #      username: ENC(VUKxrYEb2eEVncT0XD7eeg==)
-    #      password: ENC(cGqwrzSfPJ96ZWhzjecvMoL80gulmH1r)
-    #      driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${LOCAL_DB_NAME}
+    username: ${LOCAL_DB_USER_NAME}
+    password: ${LOCAL_DB_USER_PASSWORD}
   jpa:
     show-sql: true
     open-in-view: false


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

DB가 dev, prod 용으로 구성됨에 따라, 작업환경에 따른 application.yml 분리 작업을 진행했습니다. 
* application.yml : DB를 제외한 모든 값은 기존과 동일합니다. 활성 프로파일을 따로 설정하지 않았을 경우, application-dev.yml이 실행되도록 했습니다. 
* application-dev.yml : dev용 DB에 관한 정보입니다. application.yml의 datasource를 덮어쓰기 합니다. 
* application-prod.yml : prod용 DB에 관한 정보입니다. application.yml의 datasource를 덮어쓰기 합니다. 또한 read/write에 따라 다른 DB 엔드포인트로 라우팅 됩니다. 
* DataSourceConfig : 기존에 dev용 DB와 연결되어있을 경우, 에러가 나서 주석처리를 했습니다. 작업 환경을 바꿀 때마다 주석을 해제하는 것이 불편해서 @Profile("prod") 어노테이션을 추가했습니다. 해당 어노테이션을 통해, 활성 프로파일이 prod인 경우에만 (= application-prod.yml 사용) 해당 코드가 유효하도록 설정했습니다. 


++ 이 후에 배포까지는 감이 잘 안와서.. 이 후 CI/CD에 문제가 생긴다면 이 부분도 고민해봐야할 듯 합니다. 

closed #207 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
