### PR TITLE
Refactor : 로그인 및 회원가입 로직 수정

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/controller/AuthController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.fastcampus.oruryclient.auth.converter.message.AuthMessage;
 import org.fastcampus.oruryclient.auth.converter.request.LoginRequest;
 import org.fastcampus.oruryclient.auth.converter.request.SignUpRequest;
 import org.fastcampus.oruryclient.auth.converter.response.LoginResponse;
+import org.fastcampus.oruryclient.auth.converter.response.SignUpResponse;
 import org.fastcampus.oruryclient.auth.jwt.JwtTokenProvider;
 import org.fastcampus.oruryclient.auth.service.AuthService;
 import org.fastcampus.oruryclient.auth.strategy.LoginStrategy;
@@ -14,6 +15,7 @@ import org.fastcampus.oruryclient.auth.strategy.LoginStrategyManager;
 import org.fastcampus.orurycommon.error.code.AuthErrorCode;
 import org.fastcampus.orurydomain.auth.dto.JwtToken;
 import org.fastcampus.orurydomain.auth.dto.LoginDto;
+import org.fastcampus.orurydomain.auth.dto.SignUpDto;
 import org.fastcampus.orurydomain.base.converter.ApiResponse;
 import org.fastcampus.orurydomain.user.dto.UserDto;
 import org.springframework.http.HttpStatus;
@@ -33,14 +35,17 @@ public class AuthController {
 
     @Operation(summary = "회원가입", description = "소셜 로그인을 통해 전달받은 정보를 기반으로 회원가입 수행")
     @PostMapping("/sign-up")
-    public ApiResponse<Object> signUp(@RequestBody SignUpRequest request) {
+    public ApiResponse<SignUpResponse> signUp(@RequestBody SignUpRequest request) {
         UserDto userDto = request.toDto();
-
         authService.signUp(userDto);
 
-        return ApiResponse.builder()
+        SignUpDto signUpDto = authService.getSignUpDto(userDto);
+        SignUpResponse signUpResponse = SignUpResponse.of(signUpDto);
+
+        return ApiResponse.<SignUpResponse>builder()
                 .status(HttpStatus.OK.value())
                 .message(AuthMessage.SIGNUP_SUCCESS.getMessage())
+                .data(signUpResponse)
                 .build();
     }
 

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/converter/response/LoginResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/converter/response/LoginResponse.java
@@ -41,4 +41,15 @@ public record LoginResponse(
                 loginDto.jwtToken().refreshToken()
         );
     }
+
+    public static LoginResponse fromNoUser(LoginDto loginDto) {
+        return new LoginResponse(
+                null,
+                loginDto.userDto().email(),
+                loginDto.userDto().signUpType(),
+                null,
+                loginDto.jwtToken().accessToken(),
+                null
+        );
+    }
 }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/converter/response/SignUpResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/converter/response/SignUpResponse.java
@@ -1,4 +1,44 @@
 package org.fastcampus.oruryclient.auth.converter.response;
 
-public class SignUpResponse {
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.fastcampus.orurydomain.auth.dto.SignUpDto;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SignUpResponse(
+        Long id,
+        String email,
+        int signUpType,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {
+    public static SignUpResponse of(
+            Long id,
+            String email,
+            int signUpType,
+            String nickname,
+            String accessToken,
+            String refreshToken
+    ) {
+        return new SignUpResponse(
+                id,
+                email,
+                signUpType,
+                nickname,
+                accessToken,
+                refreshToken
+        );
+    }
+
+    public static SignUpResponse of(SignUpDto signUpDto) {
+        return new SignUpResponse(
+                signUpDto.userDto().id(),
+                signUpDto.userDto().email(),
+                signUpDto.userDto().signUpType(),
+                signUpDto.userDto().nickname(),
+                signUpDto.jwtToken().accessToken(),
+                signUpDto.jwtToken().refreshToken()
+        );
+    }
 }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilter.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilter.java
@@ -33,6 +33,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         Authentication authentication = null;
         try {
             accessToken = jwtTokenProvider.getTokenFromRequest(request);
+
             authentication = jwtTokenProvider.getAuthenticationFromAccessToken(accessToken);
         } catch (AuthException e) {
             jwtExceptionHandler(response, e);
@@ -47,7 +48,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludePath = {"/api/v1/auth", "/swagger-ui", "/v3/api-docs", "/favicon.ico", "/actuator/prometheus"};
+        String[] excludePath = {"/api/v1/auth/login", "/api/v1/auth/refresh", "/swagger-ui", "/v3/api-docs", "/favicon.ico", "/actuator/prometheus"};
         String path = request.getRequestURI();
         return Arrays.stream(excludePath)
                 .anyMatch(path::startsWith);

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProvider.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProvider.java
@@ -73,6 +73,15 @@ public class JwtTokenProvider {
             throw new AuthException(TokenErrorCode.EXPIRED_ACCESS_TOKEN);
         }
 
+        // 비회원은 토큰에 email 필드가 있으므로, 해당 필드로 검증 가능
+        if (claims.get("email") != null) {
+            // 임시 Authentication 세팅
+            UserPrincipal userDetails = UserPrincipal.fromToken(0L, claims.get("email").toString(), Constants.ROLE_USER.getMessage());
+            List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(Constants.ROLE_USER.getMessage()));
+
+            return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
+        }
+
         UserPrincipal userDetails = UserPrincipal.fromToken((long) (int) claims.get("id"), claims.getSubject(), Constants.ROLE_USER.getMessage());
         List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(Constants.ROLE_USER.getMessage()));
 

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProvider.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenProvider.java
@@ -37,6 +37,9 @@ public class JwtTokenProvider {
     private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7L; // 7일
     private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14L; // 14일
 
+    // 비회원 전용 토큰
+    private static final long NO_USER_ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 30L; // 30분
+
     private final SecretKey secretKey;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -122,12 +125,28 @@ public class JwtTokenProvider {
         return JwtToken.of(accessToken, refreshToken);
     }
 
+    public JwtToken issueNoUserJwtTokens(String email) {
+        String accessToken = noUserCreateJwtToken(email);
+
+        return JwtToken.of(accessToken, null);
+    }
+
     private String createJwtToken(Long id, String email, long expirationTime) {
         return Jwts.builder()
                 .subject(email)
                 .claim("id", id)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expirationTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private String noUserCreateJwtToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .claim("email", email)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + JwtTokenProvider.NO_USER_ACCESS_TOKEN_EXPIRATION_TIME))
                 .signWith(secretKey)
                 .compact();
     }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/service/AuthService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/service/AuthService.java
@@ -1,8 +1,14 @@
 package org.fastcampus.oruryclient.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import org.fastcampus.oruryclient.auth.jwt.JwtTokenProvider;
+import org.fastcampus.orurycommon.error.code.AuthErrorCode;
 import org.fastcampus.orurycommon.error.code.UserErrorCode;
+import org.fastcampus.orurycommon.error.exception.AuthException;
 import org.fastcampus.orurycommon.error.exception.BusinessException;
+import org.fastcampus.orurydomain.auth.dto.JwtToken;
+import org.fastcampus.orurydomain.auth.dto.SignUpDto;
+import org.fastcampus.orurydomain.user.db.model.User;
 import org.fastcampus.orurydomain.user.db.repository.UserRepository;
 import org.fastcampus.orurydomain.user.dto.UserDto;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -13,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
     private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public void signUp(UserDto userDto) {
@@ -21,5 +28,13 @@ public class AuthService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(UserErrorCode.DUPLICATED_USER);
         }
+    }
+
+    public SignUpDto getSignUpDto(UserDto userDto) {
+        User user = userRepository.findByEmail(userDto.email())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_EXISTING_USER_ACCOUNT));
+        JwtToken jwtToken = jwtTokenProvider.issueJwtTokens(user.getId(), user.getEmail());
+
+        return SignUpDto.of(UserDto.from(user), jwtToken);
     }
 }

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/auth/strategy/KakaoLoginStrategy.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/auth/strategy/KakaoLoginStrategy.java
@@ -61,7 +61,7 @@ public class KakaoLoginStrategy implements LoginStrategy {
 
         // 비회원인 경우
         if (user.isEmpty()) {
-            throw new AuthException(AuthErrorCode.NOT_EXISTING_USER_ACCOUNT);
+            return LoginDto.fromNoUser(email, signUpType, jwtTokenProvider.issueNoUserJwtTokens(email), AuthMessage.NOT_EXISTING_USER_ACCOUNT.getMessage());
         }
 
         // 다른 소셜 로그인으로 가입한 회원인 경우

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/auth/jwt/JwtTokenFilterTest.java
@@ -137,7 +137,7 @@ class JwtTokenFilterTest {
     @Test
     void when_ExcludePath_Then_should_ShouldNotFilterSuccessfully() throws ServletException, IOException {
         // given
-        String[] excludePath = {"/api/v1/auth", "/swagger-ui", "/v3/api-docs", "/favicon.ico"};
+        String[] excludePath = {"/api/v1/auth/login", "/api/v1/auth/refresh", "/swagger-ui", "/v3/api-docs", "/favicon.ico"};
 
         for (String path : excludePath) {
             request.setRequestURI(path + "/temp-path");

--- a/orury-domain/src/main/java/org/fastcampus/orurydomain/auth/dto/LoginDto.java
+++ b/orury-domain/src/main/java/org/fastcampus/orurydomain/auth/dto/LoginDto.java
@@ -18,4 +18,28 @@ public record LoginDto(
                 flag
         );
     }
+
+    public static LoginDto fromNoUser(
+            String email,
+            int signUpType,
+            JwtToken jwtToken,
+            String flag
+    ) {
+        return new LoginDto(
+                UserDto.of(
+                        null,
+                        email,
+                        null,
+                        null,
+                        signUpType,
+                        9,
+                        null,
+                        null,
+                        null,
+                        null
+                ),
+                jwtToken,
+                flag
+        );
+    }
 }

--- a/orury-domain/src/main/java/org/fastcampus/orurydomain/auth/dto/SignUpDto.java
+++ b/orury-domain/src/main/java/org/fastcampus/orurydomain/auth/dto/SignUpDto.java
@@ -1,0 +1,19 @@
+package org.fastcampus.orurydomain.auth.dto;
+
+import org.fastcampus.orurydomain.user.dto.UserDto;
+
+public record SignUpDto(
+        UserDto userDto,
+        JwtToken jwtToken
+) {
+    public static SignUpDto of(
+            UserDto userDto,
+            JwtToken jwtToken
+    ) {
+        return new SignUpDto(
+                userDto,
+                jwtToken
+        );
+    }
+}
+


### PR DESCRIPTION
## 개요
비회원 케이스에 대한 회원가입과 로그인 로직을 개선했습니다.

### 상세 내용
**[로그인 api 호출 시 이메일 및 비회원 전용 토큰 전달]**
비회원인 경우, 프론트 측에서 회원가입에 필요한 이메일을 받아올 수 없는 상황이 되었습니다.
이를 해결하기 위해, 로그인 시 비회원인 경우는 별도로 response를 설정해주는 방향으로 개발을 진행했습니다.

**[회원가입 보안 로직 추가]**
기존엔 회원가입 api를 호출하면 아무런 보안적인 방어로직이 구축되어 있지 않았습니다.
하여, 기존에 jwt토큰 필터로 보안처리를 하고 있었기 때문에, 회원가입 api를 호출할 때 액세스 토큰이 없으면 비정상적인 접근으로 판단, 예외를 던져줍니다.

**[회원가입 이후 로직]**
회원가입 이후, 일반 로그인과 동일하게 액세스 & 리프레쉬 토큰을 던져줍니다.
이를 통해 사용자는 바로 홈 화면으로 이동이 가능해집니다.

코드가 조금 더러운데, 프론트에서 작업을 빨리 해야하기 때문에 일단 올려놓고, 바로 리팩토링 및 테스트코드 작성 작업 진행하도록 하겠습니다.

closed #216 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
