### PR TITLE
Refactor : 암장 카카오맵 링크 추가 & 암장 영업시간 null인 경우 분기 처리

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/gym/converter/response/GymResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/gym/converter/response/GymResponse.java
@@ -2,7 +2,6 @@ package org.fastcampus.oruryclient.gym.converter.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import org.fastcampus.orurycommon.util.ImageUrlConverter;
 import org.fastcampus.orurydomain.gym.dto.GymDto;
 
@@ -23,6 +22,7 @@ public record GymResponse(
         Position position,
         String brand,
         String phoneNumber,
+        String kakaoMapLink,
         String instagramLink,
         String homepageLink,
         String settingDay,
@@ -49,6 +49,7 @@ public record GymResponse(
                 Position.of(gymDto.latitude(), gymDto.longitude()),
                 gymDto.brand(),
                 gymDto.phoneNumber(),
+                "https://map.kakao.com/?itemId=" + gymDto.kakaoId(),
                 gymDto.instagramLink(),
                 gymDto.homepageLink(),
                 gymDto.settingDay(),

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/gym/service/GymService.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/gym/service/GymService.java
@@ -44,6 +44,9 @@ public class GymService {
         DayOfWeek today = LocalDateTime.now().getDayOfWeek();
         String businessHour = gymDto.businessHours().get(today);
 
+        if (businessHour == null)
+            return false;
+
         LocalTime openTime = BusinessHoursConverter.extractOpenTime(businessHour);
         LocalTime closeTime = BusinessHoursConverter.extractCloseTime(businessHour);
         LocalTime nowTime = LocalTime.now();

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/gym/service/GymServiceTest.java
@@ -183,6 +183,19 @@ class GymServiceTest {
     }
 
     @Test
+    @DisplayName("GymDto의 현재 요일 영업시간이 비어있다면(null이라면), false를 반환한다.")
+    void when_BusinessHoursIsNull_Then_ReturnFalse() {
+        //given
+        GymDto gymDto = createGymDto(null);
+
+        //when
+        boolean doingBusiness = gymService.checkDoingBusiness(gymDto);
+
+        //then
+        assertFalse(doingBusiness);
+    }
+
+    @Test
     @DisplayName("존재하는 gymId가 들어오면, 아무것도 하지 않는다.")
     void when_IdOfExistingGym_Then_DoNothing() {
         //given
@@ -307,6 +320,37 @@ class GymServiceTest {
                 openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
                 openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
                 openTime.getHour() + ":" + openTime.getMinute() + "-" + closeTime.getHour() + ":" + closeTime.getMinute(),
+                "gymHomepageLink",
+                "gymRemark"
+        );
+    }
+
+    private static GymDto createGymDto(String businessHour) {
+        return GymDto.of(
+                1L,
+                "더클라임 봉은사점",
+                "kakaoid",
+                "서울시 도로명주소",
+                "서울시 지번주소",
+                40.5f,
+                23,
+                12,
+                "image.png",
+                "37.513709",
+                "127.062144",
+                "더클라임",
+                "01012345678",
+                "gymInstagramLink.com",
+                "MONDAY",
+                LocalDateTime.of(1999, 3, 1, 7, 30),
+                LocalDateTime.of(2024, 1, 23, 18, 32),
+                businessHour,
+                businessHour,
+                businessHour,
+                businessHour,
+                businessHour,
+                businessHour,
+                businessHour,
                 "gymHomepageLink",
                 "gymRemark"
         );


### PR DESCRIPTION
## 개요
### GymResponse에 카카오맵 링크 추가
- DB에 저장된 kakaoId 앞에 "https://map.kakao.com/?itemId=" 추가해서 GymResponse에 실었습니다.
### Gym businessHour 비어있는 경우(영업X) 분기 처리
- 어제 암장 초기 데이터 수집에서 영업하지 않는 날은 데이터 안 넣어 주기로 했으므로,
그에 따른 분기 처리하고, 테스트케이스 하나 추가했습니다.

closed #221 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
