### PR TITLE
Settings : 500에러시 빠르게 대응 가능한 슬랙 알림 구현

### DIFF
--- a/orury-client/src/main/resources/application.yml
+++ b/orury-client/src/main/resources/application.yml
@@ -96,6 +96,10 @@ jasypt:
   encryptor:
     password: ${JASYPT_PASSWORD}
 
+slack:
+  token: ENC(7Pd4U/iPDtDF5quQM5TzMXF7jsfv+QQYCDdckH+/T8vbz/QOYTOKX6iAGdqM5gRVusZ84cC93RpQE8qK1kW4f6tdoIf5GDu2)
+  channel: ENC(9i8/M3HKZDCGoJWCM1B1Lg6ECmK4eudW)
+
 ---
 spring:
   profiles:

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/config/ControllerTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/config/ControllerTest.java
@@ -23,6 +23,7 @@ import org.fastcampus.oruryclient.review.service.ReviewReactionService;
 import org.fastcampus.oruryclient.review.service.ReviewService;
 import org.fastcampus.oruryclient.user.controller.UserController;
 import org.fastcampus.oruryclient.user.service.UserService;
+import org.fastcampus.orurycommon.config.SlackMessage;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,4 +90,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected UserService userService;
+
+    @MockBean
+    protected SlackMessage slackMessage;
 }

--- a/orury-common/build.gradle
+++ b/orury-common/build.gradle
@@ -16,6 +16,11 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-api:2.2.0'
 
+    //slack
+    implementation("com.slack.api:bolt:1.18.0")
+    implementation("com.slack.api:bolt-servlet:1.18.0")
+    implementation("com.slack.api:bolt-jetty:1.18.0")
+    implementation 'com.slack.api:slack-api-client:1.15.0'
 }
 
 tasks.named('bootJar') {

--- a/orury-common/src/main/java/org/fastcampus/orurycommon/config/SlackMessage.java
+++ b/orury-common/src/main/java/org/fastcampus/orurycommon/config/SlackMessage.java
@@ -1,0 +1,44 @@
+package org.fastcampus.orurycommon.config;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.orurycommon.error.code.LogTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+
+@Slf4j
+@Component
+public class SlackMessage {
+    @Value("${slack.token}")
+    private String token;
+    @Value("${slack.channel}")
+    private String channel;
+
+    public void send(LogTemplate template) {
+        log.info("token : {}", token);
+        log.info("channel : {}", channel);
+        try {
+            MethodsClient methods = Slack.getInstance()
+                    .methods(token);
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(channel)
+                    .blocks(asBlocks(
+                            header(header -> header.text(plainText("🚨" + template.uri()))),
+                            divider(),
+                            section(section -> section.fields(template.toTextObjects())
+                            )))
+                    .build();
+            methods.chatPostMessage(request);
+        } catch (SlackApiException | IOException e) {
+            log.error("SlackApiException: {}", e.getMessage());
+        }
+    }
+}

--- a/orury-common/src/main/java/org/fastcampus/orurycommon/error/code/LogTemplate.java
+++ b/orury-common/src/main/java/org/fastcampus/orurycommon/error/code/LogTemplate.java
@@ -1,0 +1,36 @@
+package org.fastcampus.orurycommon.error.code;
+
+import com.slack.api.model.block.composition.TextObject;
+
+import java.util.List;
+
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+
+public record LogTemplate(
+        String uri,
+        String requestBody,
+        String requestPart,
+        String responseBody
+) {
+    public static LogTemplate of(
+            String uri,
+            String requestBody,
+            String requestPart,
+            String responseBody
+    ) {
+        return new LogTemplate(
+                uri,
+                requestBody,
+                requestPart,
+                responseBody
+        );
+    }
+
+    public List<TextObject> toTextObjects() {
+        return List.of(
+                markdownText("requestBody : " + requestBody),
+                markdownText("requestPart : " + requestPart),
+                markdownText("responseBody : " + responseBody)
+        );
+    }
+}


### PR DESCRIPTION
## 개요

500에러시 슬랙에서 확인할 수 있습니다. 

LoggerFilter에서 response.status 값이 500인 경우 해당 기능이 작동합니다.

열람 가능 목록
- uri
- request body
- request parts
- response body

실질적인 서비스를 운용할 때는 request, response 부분을 노출시키는 것은 좋지 않다고 하여 실제 서비스가 상용화 될 때 해당 부분은 제거할 예정입니다.

closed #246

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
