### PR TITLE
Chore : 마이페이지 조회 시 user_id 반환

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/user/converter/response/MypageResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/user/converter/response/MypageResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MypageResponse(
+        Long id,
         String email,
         String nickname,
         int signUpType,
@@ -18,6 +19,7 @@ public record MypageResponse(
 ) {
     public static MypageResponse of(UserDto userDto) {
         return new MypageResponse(
+                userDto.id(),
                 userDto.email(),
                 userDto.nickname(),
                 userDto.signUpType(),

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/user/controller/UserControllerTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/user/controller/UserControllerTest.java
@@ -1,4 +1,10 @@
-package org.fastcampus.oruryclient.user.db.controller;
+package org.fastcampus.oruryclient.user.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.fastcampus.oruryclient.config.ControllerTest;
 import org.fastcampus.oruryclient.config.WithUserPrincipal;
@@ -22,12 +28,6 @@ import org.springframework.http.MediaType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 //@Disabled
 @DisplayName("[Controller] 유저 마이페이지 관련 테스트")


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

현재 마이페이지 조회 시 user_id를 받을 필요가 없었어서 response에 추가하지 않았었다가, 프론트 요청으로 추가합니다 ! 
추가로 user testcode 경로 잘못되어서 경로 이동도 했습니다. 

closed #258 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
