### PR TITLE
Refactor : WithCursorResponse 리팩토링

### DIFF
--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/controller/CommentController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/controller/CommentController.java
@@ -1,29 +1,38 @@
 package org.fastcampus.oruryclient.comment.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.fastcampus.oruryclient.comment.converter.message.CommentMessage;
 import org.fastcampus.oruryclient.comment.converter.request.CommentCreateRequest;
 import org.fastcampus.oruryclient.comment.converter.request.CommentUpdateRequest;
 import org.fastcampus.oruryclient.comment.converter.response.CommentResponse;
-import org.fastcampus.oruryclient.comment.converter.response.CommentsWithCursorResponse;
 import org.fastcampus.oruryclient.comment.service.CommentLikeService;
 import org.fastcampus.oruryclient.comment.service.CommentService;
+import org.fastcampus.oruryclient.global.WithCursorResponse;
 import org.fastcampus.oruryclient.post.service.PostService;
 import org.fastcampus.oruryclient.user.service.UserService;
-import org.fastcampus.orurydomain.global.constants.NumberConstants;
 import org.fastcampus.orurydomain.base.converter.ApiResponse;
 import org.fastcampus.orurydomain.comment.dto.CommentDto;
+import org.fastcampus.orurydomain.global.constants.NumberConstants;
 import org.fastcampus.orurydomain.post.dto.PostDto;
 import org.fastcampus.orurydomain.user.dto.UserDto;
 import org.fastcampus.orurydomain.user.dto.UserPrincipal;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -54,7 +63,7 @@ public class CommentController {
 
     @Operation(summary = "댓글 조회", description = "게시글 id와 cursor값을 받아, '게시글 id와 cursor값에 따른 다음 댓글 목록'과 'cursor값(목록의 마지막 댓글 id / 조회된 댓글 없다면 -1L)'을 돌려준다.")
     @GetMapping("/{postId}")
-    public ApiResponse<CommentsWithCursorResponse> getCommentsByPostId(@PathVariable Long postId, @RequestParam Long cursor, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    public ApiResponse<WithCursorResponse> getCommentsByPostId(@PathVariable Long postId, @RequestParam Long cursor, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         PostDto postDto = postService.getPostDtoById(postId);
         List<CommentDto> commentDtos = commentService.getCommentDtosByPost(postDto, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE));
 
@@ -65,9 +74,10 @@ public class CommentController {
                 })
                 .toList();
 
-        CommentsWithCursorResponse response = CommentsWithCursorResponse.of(commentResponses);
+        //CommentsWithCursorResponse response = CommentsWithCursorResponse.of(commentResponses);
+        WithCursorResponse response = WithCursorResponse.of(commentResponses);
 
-        return ApiResponse.<CommentsWithCursorResponse>builder()
+        return ApiResponse.<WithCursorResponse>builder()
                 .status(HttpStatus.OK.value())
                 .message(CommentMessage.COMMENTS_READ.getMessage())
                 .data(response)

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/comment/converter/response/CommentResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/comment/converter/response/CommentResponse.java
@@ -2,6 +2,8 @@ package org.fastcampus.oruryclient.comment.converter.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import org.fastcampus.oruryclient.global.IdIdentifiable;
 import org.fastcampus.orurydomain.comment.dto.CommentDto;
 
 import java.time.LocalDateTime;
@@ -20,7 +22,7 @@ public record CommentResponse(
         LocalDateTime updatedAt,
         boolean isLike,
         int deleted
-) {
+) implements IdIdentifiable {
     public static CommentResponse of(CommentDto commentDto, Long userId, boolean isLike) {
         return new CommentResponse(
                 commentDto.id(),

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/global/WithCursorResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/global/WithCursorResponse.java
@@ -1,7 +1,9 @@
 package org.fastcampus.oruryclient.global;
 
+import org.fastcampus.oruryclient.comment.converter.response.CommentResponse;
 import org.fastcampus.orurydomain.global.constants.NumberConstants;
 
+import java.util.Comparator;
 import java.util.List;
 
 public record WithCursorResponse<T extends IdIdentifiable>(
@@ -14,6 +16,18 @@ public record WithCursorResponse<T extends IdIdentifiable>(
                 : list.get(list.size() - 1).id();
         return new WithCursorResponse<>(list, newCursor);
     }
+
+    public static WithCursorResponse of(List<CommentResponse> list) {
+
+        Long cursor = list.stream()
+                .filter(commentResponse -> commentResponse.parentId() == NumberConstants.PARENT_COMMENT)
+                .map(CommentResponse::id)
+                .max(Comparator.naturalOrder())
+                .orElse(NumberConstants.LAST_CURSOR);
+
+        return new WithCursorResponse(list, cursor);
+    }
+
 
     private static Long determineCursorWhenEmpty(Long cursor) {
         return cursor.equals(NumberConstants.FIRST_CURSOR)

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/controller/PostController.java
@@ -1,14 +1,11 @@
 package org.fastcampus.oruryclient.post.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.fastcampus.oruryclient.global.WithCursorResponse;
 import org.fastcampus.oruryclient.post.converter.message.PostMessage;
 import org.fastcampus.oruryclient.post.converter.request.PostCreateRequest;
 import org.fastcampus.oruryclient.post.converter.request.PostUpdateRequest;
 import org.fastcampus.oruryclient.post.converter.response.PostResponse;
 import org.fastcampus.oruryclient.post.converter.response.PostsResponse;
-import org.fastcampus.oruryclient.post.converter.response.PostsWithCursorResponse;
 import org.fastcampus.oruryclient.post.converter.response.PostsWithPageResponse;
 import org.fastcampus.oruryclient.post.service.PostLikeService;
 import org.fastcampus.oruryclient.post.service.PostService;
@@ -22,10 +19,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -73,15 +82,17 @@ public class PostController {
 
     @Operation(summary = "카테고리별 게시글 목록 조회", description = "카테고리(1: 자유게시판, 2: Q&A게시판)와 cursor값을 받아, '카테고리와 cursor값에 따른 다음 게시글 목록'과 'cursor값(목록의 마지막 게시글 id / 조회된 게시글 없다면 -1L)'을 돌려준다.")
     @GetMapping("/category/{category}")
-    public ApiResponse<PostsWithCursorResponse> getPostsByCategory(@PathVariable int category, @RequestParam Long cursor) {
+    public ApiResponse<WithCursorResponse> getPostsByCategory(@PathVariable int category, @RequestParam Long cursor) {
         List<PostDto> postDtos = postService.getPostDtosByCategory(category, cursor, PageRequest.of(0, NumberConstants.POST_PAGINATION_SIZE));
         List<PostsResponse> postsResponses = postDtos.stream()
                 .map(PostsResponse::of)
                 .toList();
 
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses, cursor);
+        //PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses, cursor);
+        WithCursorResponse response = WithCursorResponse.of(postsResponses, cursor);
 
-        return ApiResponse.<PostsWithCursorResponse>builder()
+
+        return ApiResponse.<WithCursorResponse>builder()
                 .status(HttpStatus.OK.value())
                 .message(PostMessage.POSTS_READ.getMessage())
                 .data(response)
@@ -90,15 +101,15 @@ public class PostController {
 
     @Operation(summary = "검색어에 따른 게시글 목록 조회", description = "검색어와 cursor값을 받아, '검색어와 cursor값에 따른 다음 게시글 목록'과 'cursor값(목록의 마지막 게시글 id / 조회된 게시글 없다면 -1L)'을 돌려준다.")
     @GetMapping
-    public ApiResponse<PostsWithCursorResponse> getPostsBySearchWord(@RequestParam String searchWord, @RequestParam Long cursor) {
+    public ApiResponse<WithCursorResponse> getPostsBySearchWord(@RequestParam String searchWord, @RequestParam Long cursor) {
         List<PostDto> postDtos = postService.getPostDtosBySearchWord(searchWord, cursor, PageRequest.of(0, NumberConstants.POST_PAGINATION_SIZE));
         List<PostsResponse> postsResponses = postDtos.stream()
                 .map(PostsResponse::of)
                 .toList();
 
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postsResponses, cursor);
+        WithCursorResponse response = WithCursorResponse.of(postsResponses, cursor);
 
-        return ApiResponse.<PostsWithCursorResponse>builder()
+        return ApiResponse.<WithCursorResponse>builder()
                 .status(HttpStatus.OK.value())
                 .message(PostMessage.POSTS_READ.getMessage())
                 .data(response)

--- a/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostsResponse.java
+++ b/orury-client/src/main/java/org/fastcampus/oruryclient/post/converter/response/PostsResponse.java
@@ -2,6 +2,8 @@ package org.fastcampus.oruryclient.post.converter.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import org.fastcampus.oruryclient.global.IdIdentifiable;
 import org.fastcampus.orurydomain.post.dto.PostDto;
 
 import java.time.LocalDateTime;
@@ -21,7 +23,7 @@ public record PostsResponse(
         String userProfileImage,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
-) {
+) implements IdIdentifiable {
     public static PostsResponse of(PostDto postDto) {
 
         return new PostsResponse(

--- a/orury-client/src/test/java/org/fastcampus/oruryclient/post/controller/PostControllerTest.java
+++ b/orury-client/src/test/java/org/fastcampus/oruryclient/post/controller/PostControllerTest.java
@@ -1,13 +1,28 @@
 package org.fastcampus.oruryclient.post.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+
 import org.fastcampus.oruryclient.config.ControllerTest;
 import org.fastcampus.oruryclient.config.WithUserPrincipal;
+import org.fastcampus.oruryclient.global.WithCursorResponse;
 import org.fastcampus.oruryclient.post.converter.message.PostMessage;
 import org.fastcampus.oruryclient.post.converter.request.PostCreateRequest;
 import org.fastcampus.oruryclient.post.converter.request.PostUpdateRequest;
 import org.fastcampus.oruryclient.post.converter.response.PostsResponse;
-import org.fastcampus.oruryclient.post.converter.response.PostsWithCursorResponse;
 import org.fastcampus.oruryclient.post.converter.response.PostsWithPageResponse;
 import org.fastcampus.orurycommon.error.code.PostErrorCode;
 import org.fastcampus.orurycommon.error.code.UserErrorCode;
@@ -28,15 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.http.HttpMethod.PATCH;
-import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 //@Disabled
 @DisplayName("[Controller] 게시글 관련 테스트")
@@ -454,7 +460,7 @@ class PostControllerTest extends ControllerTest {
         int category = 1;
         Long cursor = 1L;
         for (int i = 1; i <= NumberConstants.POST_PAGINATION_SIZE; i++) postDtos.add(createPostDto((long) i));
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postDtos.stream()
+        WithCursorResponse<PostsResponse> response = WithCursorResponse.of(postDtos.stream()
                 .map(PostsResponse::of)
                 .toList(), cursor);
 
@@ -473,13 +479,13 @@ class PostControllerTest extends ControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value(code.getMessage()))
-                .andExpect(jsonPath("$.data.posts[0].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[0].id").value(response.list()
                         .get(0)
                         .id()))
-                .andExpect(jsonPath("$.data.posts[1].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[1].id").value(response.list()
                         .get(1)
                         .id()))
-                .andExpect(jsonPath("$.data.posts[9].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[9].id").value(response.list()
                         .get(9)
                         .id()))
                 .andExpect(jsonPath("$.data.cursor").value(response.cursor()))
@@ -499,9 +505,6 @@ class PostControllerTest extends ControllerTest {
         List<PostDto> postDtos = new ArrayList<>();
         int category = 1;
         Long cursor = 1L;
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postDtos.stream()
-                .map(PostsResponse::of)
-                .toList(), cursor);
 
         PostMessage code = PostMessage.POSTS_READ;
 
@@ -537,7 +540,7 @@ class PostControllerTest extends ControllerTest {
         Pageable pageable = PageRequest.of(0, NumberConstants.POST_PAGINATION_SIZE);
         List<PostDto> postDtos = new ArrayList<>();
         for (int i = 1; i <= NumberConstants.POST_PAGINATION_SIZE; i++) postDtos.add(createPostDto((long) i));
-        PostsWithCursorResponse response = PostsWithCursorResponse.of(postDtos.stream()
+        WithCursorResponse<PostsResponse> response = WithCursorResponse.of(postDtos.stream()
                 .map(PostsResponse::of)
                 .toList(), cursor);
 
@@ -557,13 +560,13 @@ class PostControllerTest extends ControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value(code.getMessage()))
-                .andExpect(jsonPath("$.data.posts[0].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[0].id").value(response.list()
                         .get(0)
                         .id()))
-                .andExpect(jsonPath("$.data.posts[1].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[1].id").value(response.list()
                         .get(1)
                         .id()))
-                .andExpect(jsonPath("$.data.posts[9].id").value(response.posts()
+                .andExpect(jsonPath("$.data.list[9].id").value(response.list()
                         .get(9)
                         .id()))
                 .andExpect(jsonPath("$.data.cursor").value(response.cursor()))


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
조회 시 무한 스크롤을 사용하여 cursor 값을 필요로 하는 도메인들(post, comment,... )이 WithCursorResponse를 사용하도록 리팩토링 했습니다. 
이전에 마이페이지에서 내가 쓴 리뷰, 게시글 등을 조회 시에 ~~WithCursorResponse 코드가 중복되어 있어, 모든 response 객체를 담는 WithCursorResponse를 만들었습니다.
이에 따라 ~~WithCursorResponse를 WithCursorResponse로 리팩토링 했습니다.

다만, 리팩토링을 하다보니 WithCursorResponse에 담을 수 없는 값들이 있어서 의견을 구합니다.
- Post 중 인기 게시글 조회 (커서값 말고 page를 반환하여 담을 수 없음)
- 리뷰 (커서값 말고 다른 값들도 담고 있어 담을 수 없음)

혹시 한번에 처리할 수 있는 방법이나, 다른 의견(걍 원래대로 가자,,, 등)이 있다면 리뷰 부탁드립니다 !

closed #203 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
