### PR TITLE
Refactor : 회원가입용 토큰 만료 시, 다른 에러 메세지 반환

### DIFF
--- a/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
+++ b/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
@@ -111,8 +111,8 @@ public class JwtTokenProvider {
             throw new AuthException(TokenErrorCode.EXPIRED_REFRESH_TOKEN);
         }
 
-        refreshTokenRepositor.findByValue(refreshToken)
-                .orElseThrow(() -> new AuthException(TokenErrorCode.EXPIRED_REFRESH_TOKEN));
+        if (!refreshTokenRepository.existsByValue(refreshToken))
+            throw new AuthException(TokenErrorCode.EXPIRED_REFRESH_TOKEN);
 
         // Access 토큰, Refresh 토큰 모두 재발급
         return issueJwtTokens((long) (int) claims.get("id"), claims.getSubject());

--- a/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
+++ b/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
@@ -68,7 +68,7 @@ public class JwtTokenProvider {
             throw new AuthException(TokenErrorCode.INVALID_ACCESS_TOKEN);
         } catch (final ExpiredJwtException exception) {
             if (Objects.nonNull(exception.getClaims().get("email"))) {
-                throw new AuthException(TokenErrorCode.EXPIRED_SIGNUP_TOKEN);
+                throw new AuthException(TokenErrorCode.EXPIRED_NO_USER_TOKEN);
             }
             throw new AuthException(TokenErrorCode.EXPIRED_ACCESS_TOKEN);
         } catch (final JwtException exception) {

--- a/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
+++ b/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenProvider.java
@@ -1,17 +1,14 @@
 package org.orury.client.auth.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.orury.domain.global.constants.Constants;
 import org.orury.common.error.code.TokenErrorCode;
 import org.orury.common.error.exception.AuthException;
 import org.orury.domain.auth.db.model.RefreshToken;
 import org.orury.domain.auth.db.repository.RefreshTokenRepository;
 import org.orury.domain.auth.dto.JwtToken;
+import org.orury.domain.global.constants.Constants;
 import org.orury.domain.user.dto.UserPrincipal;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -67,10 +65,13 @@ public class JwtTokenProvider {
         try {
             claims = parseToken(accessToken);
         } catch (final MalformedJwtException | IllegalArgumentException exception) {
-            log.error("### Error when parsing token: {}", exception.getMessage());
             throw new AuthException(TokenErrorCode.INVALID_ACCESS_TOKEN);
+        } catch (final ExpiredJwtException exception) {
+            if (Objects.nonNull(exception.getClaims().get("email"))) {
+                throw new AuthException(TokenErrorCode.EXPIRED_SIGNUP_TOKEN);
+            }
+            throw new AuthException(TokenErrorCode.EXPIRED_ACCESS_TOKEN);
         } catch (final JwtException exception) {
-            log.error("### Error when parsing token: {}", exception.getMessage());
             throw new AuthException(TokenErrorCode.EXPIRED_ACCESS_TOKEN);
         }
 
@@ -110,7 +111,7 @@ public class JwtTokenProvider {
             throw new AuthException(TokenErrorCode.EXPIRED_REFRESH_TOKEN);
         }
 
-        refreshTokenRepository.findByValue(refreshToken)
+        refreshTokenRepositor.findByValue(refreshToken)
                 .orElseThrow(() -> new AuthException(TokenErrorCode.EXPIRED_REFRESH_TOKEN));
 
         // Access 토큰, Refresh 토큰 모두 재발급

--- a/orury-client/src/test/java/org/orury/client/auth/jwt/JwtTokenProviderTest.java
+++ b/orury-client/src/test/java/org/orury/client/auth/jwt/JwtTokenProviderTest.java
@@ -1,17 +1,16 @@
 package org.orury.client.auth.jwt;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.orury.domain.global.constants.Constants;
-import org.orury.common.error.code.TokenErrorCode;
-import org.orury.common.error.exception.AuthException;
-import org.orury.domain.auth.db.model.RefreshToken;
-import org.orury.domain.auth.db.repository.RefreshTokenRepository;
-import org.orury.domain.user.dto.UserPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.orury.common.error.code.TokenErrorCode;
+import org.orury.common.error.exception.AuthException;
+import org.orury.domain.auth.db.repository.RefreshTokenRepository;
+import org.orury.domain.global.constants.Constants;
+import org.orury.domain.user.dto.UserPrincipal;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -19,7 +18,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,6 +47,7 @@ class JwtTokenProviderTest {
     // 만료된 토큰
     private final String EXPIRED_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNzE2LCJleHAiOjE3MDYyNDM3NzZ9.nTKrQ7HxWiS9dG0WixQ6F578ugkSfN2TosXUnHr_fpc";
     private final String EXPIRED_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJpZCI6MSwiaWF0IjoxNzA2MjQzNzE2LCJleHAiOjE3MDYyNDM4MzZ9.v8AKma4QS3zCg1UzejUPf-uuY5BpwM7OiACNljY-QxM";
+    private final String EXPIRED_NO_USER_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbEBvcnVyeS5jb20iLCJlbWFpbCI6ImVtYWlsQG9ydXJ5LmNvbSIsImlhdCI6MTcwODYwMTgzOCwiZXhwIjoxNzA4NjAzNjM4fQ.nljAg1le8v6I0H6EKcF1pcgLzRUxY_jHHiQKKygA6mg";
 
     @BeforeEach
     public void setUp() {
@@ -175,6 +174,21 @@ class JwtTokenProviderTest {
                 () -> jwtTokenProvider.getAuthenticationFromAccessToken(accessToken));
 
         assertEquals(TokenErrorCode.EXPIRED_ACCESS_TOKEN.getStatus(), exception.getStatus());
+        assertEquals(TokenErrorCode.EXPIRED_ACCESS_TOKEN.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("만료된 비회원용 액세스토큰이 들어오면, ExpiredNoUserToken 예외를 반환한다.")
+    @Test
+    void when_ExpiredNoUserAccessToken_Then_ExpiredAccessTokenException() {
+        // given
+        String accessToken = EXPIRED_NO_USER_TOKEN;
+
+        // when & then
+        AuthException exception = assertThrows(AuthException.class,
+                () -> jwtTokenProvider.getAuthenticationFromAccessToken(accessToken));
+
+        assertEquals(TokenErrorCode.EXPIRED_NO_USER_TOKEN.getStatus(), exception.getStatus());
+        assertEquals(TokenErrorCode.EXPIRED_NO_USER_TOKEN.getMessage(), exception.getMessage());
     }
 
     @DisplayName("만료되지 않고 유효한 형식의 리프레쉬토큰으로부터 생성한 인증객체를 정상적으로 반환한다.")
@@ -183,15 +197,15 @@ class JwtTokenProviderTest {
         // given
         String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
 
-        given(refreshTokenRepository.findByValue(anyString()))
-                .willReturn(Optional.of(mock(RefreshToken.class)));
+        given(refreshTokenRepository.existsByValue(anyString()))
+                .willReturn(true);
 
         // when
         jwtTokenProvider.reissueJwtTokens(refreshToken);
 
         // then
         then(refreshTokenRepository).should()
-                .findByValue(anyString());
+                .existsByValue(anyString());
     }
 
     @DisplayName("리프레쉬토큰이 null로 들어오면, InvalidRefreshToken 예외를 반환한다.")
@@ -265,8 +279,8 @@ class JwtTokenProviderTest {
         // given
         String refreshToken = "Bearer " + VALID_REFRESH_TOKEN;
 
-        given(refreshTokenRepository.findByValue(anyString()))
-                .willReturn(Optional.empty());
+        given(refreshTokenRepository.existsByValue(anyString()))
+                .willReturn(false);
 
         // when & then
         AuthException exception = assertThrows(AuthException.class,
@@ -275,7 +289,7 @@ class JwtTokenProviderTest {
         assertEquals(TokenErrorCode.EXPIRED_REFRESH_TOKEN.getStatus(), exception.getStatus());
 
         then(refreshTokenRepository).should()
-                .findByValue(anyString());
+                .existsByValue(anyString());
     }
 
     @DisplayName("id와 email을 받으면, 액세스토큰과 리프레시토큰을 생성하고 저장하여 돌려준다.")

--- a/orury-common/src/main/java/org/orury/common/error/code/TokenErrorCode.java
+++ b/orury-common/src/main/java/org/orury/common/error/code/TokenErrorCode.java
@@ -9,7 +9,8 @@ public enum TokenErrorCode implements ErrorCode {
     EXPIRED_ACCESS_TOKEN(990, "만료된 access token 입니다."),
     EXPIRED_REFRESH_TOKEN(999, "만료된 refresh token 입니다."),
     INVALID_ACCESS_TOKEN(980, "유효하지 않은 형식의 access token 입니다."),
-    INVALID_REFRESH_TOKEN(989, "유효하지 않은 형식의 refresh token 입니다.");
+    INVALID_REFRESH_TOKEN(989, "유효하지 않은 형식의 refresh token 입니다."),
+    EXPIRED_SIGNUP_TOKEN(990, "회원가입 시간이 만료됐습니다. 다시 회원가입 해주세요.");
     private final int status;
     private final String message;
 }

--- a/orury-common/src/main/java/org/orury/common/error/code/TokenErrorCode.java
+++ b/orury-common/src/main/java/org/orury/common/error/code/TokenErrorCode.java
@@ -10,7 +10,7 @@ public enum TokenErrorCode implements ErrorCode {
     EXPIRED_REFRESH_TOKEN(999, "만료된 refresh token 입니다."),
     INVALID_ACCESS_TOKEN(980, "유효하지 않은 형식의 access token 입니다."),
     INVALID_REFRESH_TOKEN(989, "유효하지 않은 형식의 refresh token 입니다."),
-    EXPIRED_SIGNUP_TOKEN(990, "회원가입 시간이 만료됐습니다. 다시 회원가입 해주세요.");
+    EXPIRED_NO_USER_TOKEN(990, "회원가입 시간이 만료됐습니다. 다시 회원가입 해주세요.");
     private final int status;
     private final String message;
 }

--- a/orury-domain/src/main/java/org/orury/domain/auth/db/repository/RefreshTokenRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/auth/db/repository/RefreshTokenRepository.java
@@ -3,8 +3,6 @@ package org.orury.domain.auth.db.repository;
 import org.orury.domain.auth.db.model.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByValue(String value);
+    boolean existsByValue(String value);
 }


### PR DESCRIPTION
## 개요
프론트에서, 비회원용 회원가입 토큰도 Authorization 헤더에 담아서 보내고 있는데,
만료 기간(30분) 이후에 회원가입 버튼을 누르면 "만료된 access token 입니다." 반환됩니다.
프론트의 동작 구분을 위해, 해당 작업에 대해 다른 에러 메세지를 보내야 합니다. (프론트 요청)

기존 코드에서 parseToken()의 토큰 파싱과정에서 자동적으로 
exp(토큰 만료시간)이 현재보다 이후라면 ExpiredJwtException이 던져집니다. 
(JwtToken의 클레임의 exp는 언제나 현재시간보다 이후여야 하기 때문.)
[링크](https://stackoverflow.com/questions/35791465/is-there-a-way-to-parse-claims-from-an-expired-jwt-token)에서 힌트를 얻어, exception.getClaims()가 수행가능함을 확인했습니다.
 
이에 따라 토큰 파싱에서 ExpiredJwtException이 발생했을 때,
클레임에 "email" 정보가 없다면 "회원가입 시간이 만료됐습니다. 다시 회원가입 해주세요." 메세지를 띄우도록 구현했습니다.
희태님께서 에러코드는 무관하다고 하셔서, 990으로 유지했습니다.

closed #295

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
