### PR TITLE
Fix : api 버저닝에 유연한 Filter의 url 체킹 적용

### DIFF
--- a/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenFilter.java
+++ b/orury-client/src/main/java/org/orury/client/auth/jwt/JwtTokenFilter.java
@@ -48,10 +48,10 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludePath = {"/api/v1/auth/login", "/api/v1/auth/refresh", "/swagger-ui", "/v3/api-docs", "/favicon.ico", "/actuator/prometheus"};
+        String[] excludePath = {"/auth/login", "/auth/refresh", "/swagger-ui", "/v3/api-docs", "/favicon.ico", "/actuator/prometheus"};
         String path = request.getRequestURI();
         return Arrays.stream(excludePath)
-                .anyMatch(path::startsWith);
+                .anyMatch(path::contains);
     }
 
     private void jwtExceptionHandler(HttpServletResponse response, AuthException exception) {

--- a/orury-common/src/main/java/org/orury/common/log/LoggerFilter.java
+++ b/orury-common/src/main/java/org/orury/common/log/LoggerFilter.java
@@ -63,7 +63,7 @@ public class LoggerFilter extends OncePerRequestFilter {
         String[] excludePath = {"/swagger-ui", "/v3/api-docs", "/actuator/prometheus"};
         String path = request.getRequestURI();
         return Arrays.stream(excludePath)
-                .anyMatch(path::startsWith);
+                .anyMatch(path::contains);
     }
 
     private String extractRequestHeader(ContentCachingRequestWrapper req) {


### PR DESCRIPTION
## 개요
- swagger 요청하는 path가 "/v3/swaggert-ui"에서 "/api/v1/v3/swaggert-ui" 변경됨에 따른
JwtTokenFilter, LoggerFilter 코드 수정입니다.

- Filter에서 shouldNotFilter()의 리스트를 startsWith()로 판별하지 않고, contains()로 판별하도록 수정했습니다.
api 버저닝에 더 유연한 대처가 가능할 것으로 생각합니다..

closed #321

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
