### PR TITLE
Fix : 회원가입 후, 유효한 userId 조회

### DIFF
--- a/orury-client/src/main/java/org/orury/client/auth/application/AuthServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/auth/application/AuthServiceImpl.java
@@ -40,7 +40,9 @@ public class AuthServiceImpl implements AuthService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(UserErrorCode.DUPLICATED_USER);
         }
-        JwtToken jwtToken = jwtTokenService.issueJwtTokens(userDto.id(), userDto.email());
+        User user = userReader.findByEmail(userDto.email())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_EXISTING_USER_ACCOUNT));
+        JwtToken jwtToken = jwtTokenService.issueJwtTokens(user.getId(), userDto.email());
         return SignUpDto.of(userDto, jwtToken);
     }
 

--- a/orury-client/src/test/java/org/orury/client/auth/application/AuthServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/auth/application/AuthServiceImplTest.java
@@ -71,11 +71,11 @@ class AuthServiceImplTest {
         authService.signUp(userDto);
 
         // then
-        then(userStore).should(times(1))
+        then(userStore).should(only())
                 .saveAndFlush(any());
         then(userReader).should(times(1))
                 .findByEmail(anyString());
-        then(jwtTokenService).should(times(1))
+        then(jwtTokenService).should(only())
                 .issueJwtTokens(anyLong(), anyString());
     }
 
@@ -95,7 +95,7 @@ class AuthServiceImplTest {
 
         assertEquals(UserErrorCode.DUPLICATED_USER.getMessage(), exception.getMessage());
 
-        then(userStore).should(times(1))
+        then(userStore).should(only())
                 .saveAndFlush(any());
         then(userReader).should(never())
                 .findByEmail(anyString());


### PR DESCRIPTION
## 개요
- 제가 Auth 리팩토링하는 과정에 있어서, 중요한 로직 하나를 빠뜨려 회원가입이 되지 않았습니다.
- 회원가입 api 에서 saveAndFlush() 후에 유효한 userId를 찾아 JwtToken을 발급해야 하는데,
유효한 userId 조회 로직을 빠뜨려서 userId가 null값으로 설정돼 있었습니다.
- 따라서 이 부분 로직 추가하여 수정했습니다..

closed #345

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
