### PR TITLE
Refactor : 이미지 처리 로직 Converter 사용

### DIFF
--- a/orury-admin/src/main/java/org/orury/admin/post/application/PostServiceImpl.java
+++ b/orury-admin/src/main/java/org/orury/admin/post/application/PostServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.orury.common.util.S3Folder.POST;
+import static org.orury.common.util.S3Folder.USER;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -51,8 +52,8 @@ public class PostServiceImpl implements PostService {
 
     private PostDto postImageConverter(Post post) {
         var links = imageReader.getImageLinks(POST, post.getImages());
-        var profileLink = imageReader.getUserImageLink(post.getUser().getProfileImage());
+        var profileLink = imageReader.getImageLink(USER, post.getUser().getProfileImage());
         var isLike = postReader.isPostLiked(post.getUser().getId(), post.getId());
-        return PostDto.from(post, links, profileLink, isLike);
+        return PostDto.from(post, isLike);
     }
 }

--- a/orury-admin/src/main/java/org/orury/admin/post/application/PostServiceImpl.java
+++ b/orury-admin/src/main/java/org/orury/admin/post/application/PostServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.common.error.code.PostErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.post.domain.PostReader;
 import org.orury.domain.post.domain.PostStore;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.orury.common.util.S3Folder.POST;
-import static org.orury.common.util.S3Folder.USER;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,7 +23,6 @@ import static org.orury.common.util.S3Folder.USER;
 public class PostServiceImpl implements PostService {
     private final PostReader postReader;
     private final PostStore postStore;
-    private final ImageReader imageReader;
     private final ImageStore imageStore;
 
     @Override
@@ -51,8 +48,6 @@ public class PostServiceImpl implements PostService {
     }
 
     private PostDto postImageConverter(Post post) {
-        var links = imageReader.getImageLinks(POST, post.getImages());
-        var profileLink = imageReader.getImageLink(USER, post.getUser().getProfileImage());
         var isLike = postReader.isPostLiked(post.getUser().getId(), post.getId());
         return PostDto.from(post, isLike);
     }

--- a/orury-admin/src/main/java/org/orury/admin/user/UserServiceImpl.java
+++ b/orury-admin/src/main/java/org/orury/admin/user/UserServiceImpl.java
@@ -4,12 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.common.error.code.UserErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.user.domain.UserReader;
 import org.orury.domain.user.domain.UserStore;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.orury.domain.user.domain.dto.UserStatus;
-import org.orury.domain.user.domain.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +20,6 @@ import java.util.List;
 public class UserServiceImpl implements UserService {
     private final UserReader userReader;
     private final UserStore userStore;
-    private final ImageReader imageReader;
 
     /**
      * 유저 id로 유저 조회
@@ -31,7 +28,7 @@ public class UserServiceImpl implements UserService {
     public UserDto getUser(Long userId) {
         var user = userReader.findUserById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND));
-        return transferUserDto(user);
+        return UserDto.from(user);
     }
 
     /**
@@ -40,7 +37,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<UserDto> getUsers() {
         return userReader.findAll().stream()
-                .map(this::transferUserDto)
+                .map(UserDto::from)
                 .toList();
     }
 
@@ -51,13 +48,5 @@ public class UserServiceImpl implements UserService {
     public void banUser(UserDto userDto) {
         var user = userDto.toEntity(UserStatus.BAN);
         userStore.save(user);
-    }
-
-    /**
-     * 유저 프로필을 링크로 변환하여 DTO 반환
-     */
-    private UserDto transferUserDto(User user) {
-        var profile = imageReader.getUserImageLink(user.getProfileImage());
-        return UserDto.from(user, profile);
     }
 }

--- a/orury-client/src/main/java/org/orury/client/comment/application/CommentServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/comment/application/CommentServiceImpl.java
@@ -19,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
+import static org.orury.common.util.S3Folder.USER;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -117,7 +119,7 @@ public class CommentServiceImpl implements CommentService {
     private List<CommentDto> convertCommentsToCommentDtos(List<Comment> comments) {
         return comments.stream()
                 .map(comment -> {
-                    var commentUserImage = imageReader.getUserImageLink(comment.getUser().getProfileImage());
+                    var commentUserImage = imageReader.getImageLink(USER, comment.getUser().getProfileImage());
                     return CommentDto.from(comment, commentUserImage);
                 })
                 .toList();

--- a/orury-client/src/main/java/org/orury/client/comment/application/CommentServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/comment/application/CommentServiceImpl.java
@@ -10,7 +10,6 @@ import org.orury.domain.comment.domain.dto.CommentDto;
 import org.orury.domain.comment.domain.dto.CommentLikeDto;
 import org.orury.domain.comment.domain.entity.Comment;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.post.domain.dto.PostDto;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -19,15 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
-import static org.orury.common.util.S3Folder.USER;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class CommentServiceImpl implements CommentService {
     private final CommentReader commentReader;
     private final CommentStore commentStore;
-    private final ImageReader imageReader;
 
     @Override
     @Transactional
@@ -117,11 +113,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     private List<CommentDto> convertCommentsToCommentDtos(List<Comment> comments) {
-        return comments.stream()
-                .map(comment -> {
-                    var commentUserImage = imageReader.getImageLink(USER, comment.getUser().getProfileImage());
-                    return CommentDto.from(comment, commentUserImage);
-                })
-                .toList();
+        return comments.stream().map(CommentDto::from).toList();
     }
 }

--- a/orury-client/src/main/java/org/orury/client/gym/application/GymServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/gym/application/GymServiceImpl.java
@@ -6,7 +6,6 @@ import org.orury.client.gym.interfaces.request.AreaGrid;
 import org.orury.common.error.code.GymErrorCode;
 import org.orury.common.error.exception.BusinessException;
 import org.orury.common.util.BusinessHoursConverter;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.gym.domain.GymReader;
 import org.orury.domain.gym.domain.GymStore;
 import org.orury.domain.gym.domain.dto.GymDto;
@@ -21,23 +20,19 @@ import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 
-import static org.orury.common.util.S3Folder.GYM;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class GymServiceImpl implements GymService {
     private final GymReader gymReader;
     private final GymStore gymStore;
-    private final ImageReader imageReader;
 
     @Override
     @Transactional(readOnly = true)
     public GymDto getGymDtoById(Long id) {
         Gym gym = gymReader.findGymById(id)
                 .orElseThrow(() -> new BusinessException(GymErrorCode.NOT_FOUND));
-        var urls = imageReader.getImageLinks(GYM, gym.getImages());
-        return GymDto.from(gym, urls);
+        return GymDto.from(gym);
     }
 
     @Override
@@ -94,7 +89,7 @@ public class GymServiceImpl implements GymService {
 
     private List<GymDto> sortGymsByDistanceAsc(List<Gym> gyms, float latitude, float longitude) {
         return gyms.stream()
-                .map(it -> GymDto.from(it, imageReader.getImageLinks(GYM, it.getImages())))
+                .map(GymDto::from)
                 .sorted(Comparator.comparingDouble(
                         o -> getDistance(latitude, longitude, o.latitude(), o.longitude())
                 ))

--- a/orury-client/src/main/java/org/orury/client/post/application/PostServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/post/application/PostServiceImpl.java
@@ -4,9 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.common.error.code.PostErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.common.util.ImageUtil;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.post.domain.PostReader;
 import org.orury.domain.post.domain.PostStore;
@@ -31,7 +29,6 @@ import static org.orury.common.util.S3Folder.POST;
 public class PostServiceImpl implements PostService {
     private final PostReader postReader;
     private final PostStore postStore;
-    private final ImageReader imageReader;
     private final ImageStore imageStore;
 
     @Override
@@ -89,19 +86,14 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public void createPost(PostDto postDto, List<MultipartFile> files) {
-        // id == null -> 생성, id != null -> 수정
-        if (postDto.id() != null) {
-            var oldImages = postDto.images();
-            if (!ImageUtil.imagesValidation(oldImages)) imageStore.delete(POST, oldImages);
-        }
         var newImages = imageStore.upload(POST, files);
+        imageStore.delete(POST, postDto.images());
         postStore.save(postDto.toEntity(newImages));
     }
 
     @Override
     public void deletePost(PostDto postDto) {
-        var oldImages = postDto.images();
-        if (!ImageUtil.imagesValidation(oldImages)) imageStore.delete(POST, oldImages);
+        imageStore.delete(POST, postDto.images());
         postStore.delete(postDto.toEntity());
     }
 
@@ -128,9 +120,7 @@ public class PostServiceImpl implements PostService {
     }
 
     private PostDto postImageConverter(Post post) {
-        var links = imageReader.getImageLinks(POST, post.getImages());
-        var profileLink = imageReader.getUserImageLink(post.getUser().getProfileImage());
         var isLike = postReader.isPostLiked(post.getUser().getId(), post.getId());
-        return PostDto.from(post, links, profileLink, isLike);
+        return PostDto.from(post, isLike);
     }
 }

--- a/orury-client/src/main/java/org/orury/client/post/application/PostServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/post/application/PostServiceImpl.java
@@ -35,7 +35,7 @@ public class PostServiceImpl implements PostService {
     @Transactional(readOnly = true)
     public List<PostDto> getPostDtosByCategory(int category, Long cursor, Pageable pageable) {
         return postReader.findByCategoryOrderByIdDesc(category, cursor, pageable).stream()
-                .map(this::postImageConverter)
+                .map(this::postDtoConverter)
                 .toList();
     }
 
@@ -43,7 +43,7 @@ public class PostServiceImpl implements PostService {
     @Transactional(readOnly = true)
     public List<PostDto> getPostDtosBySearchWord(String searchWord, Long cursor, Pageable pageable) {
         return postReader.findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, cursor, pageable).stream()
-                .map(this::postImageConverter)
+                .map(this::postDtoConverter)
                 .toList();
     }
 
@@ -51,7 +51,7 @@ public class PostServiceImpl implements PostService {
     @Transactional(readOnly = true)
     public List<PostDto> getPostDtosByUserId(Long userId, Long cursor, Pageable pageable) {
         return postReader.findByUserIdOrderByIdDesc(userId, cursor, pageable).stream()
-                .map(this::postImageConverter)
+                .map(this::postDtoConverter)
                 .toList();
     }
 
@@ -62,7 +62,7 @@ public class PostServiceImpl implements PostService {
                 NumberConstants.HOT_POSTS_BOUNDARY,
                 LocalDateTime.now().minusMonths(1L),
                 pageable
-        ).map(this::postImageConverter);
+        ).map(this::postDtoConverter);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class PostServiceImpl implements PostService {
     public PostDto getPostDtoById(Long id) {
         var post = postReader.findById(id)
                 .orElseThrow(() -> new BusinessException(PostErrorCode.NOT_FOUND));
-        return postImageConverter(post);
+        return postDtoConverter(post);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class PostServiceImpl implements PostService {
         var postUser = post.getUser().getId();
         if (!postUser.equals(userId))
             throw new BusinessException(PostErrorCode.FORBIDDEN);
-        return postImageConverter(post);
+        return postDtoConverter(post);
     }
 
     @Override
@@ -119,7 +119,7 @@ public class PostServiceImpl implements PostService {
         postStore.updateViewCount(id);
     }
 
-    private PostDto postImageConverter(Post post) {
+    private PostDto postDtoConverter(Post post) {
         var isLike = postReader.isPostLiked(post.getUser().getId(), post.getId());
         return PostDto.from(post, isLike);
     }

--- a/orury-client/src/main/java/org/orury/client/review/application/ReviewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/review/application/ReviewServiceImpl.java
@@ -53,7 +53,9 @@ public class ReviewServiceImpl implements ReviewService {
     public ReviewDto getReviewDtoById(Long reviewId, Long userId) {
         Review review = reviewReader.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ReviewErrorCode.NOT_FOUND));
-        isValidate(review.getUser().getId(), userId);
+        if (!Objects.equals(review.getUser().getId(), userId))
+            throw new BusinessException(ReviewErrorCode.FORBIDDEN);
+
         return ReviewDto.from(review);
     }
 

--- a/orury-client/src/main/java/org/orury/client/user/application/UserServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/user/application/UserServiceImpl.java
@@ -4,9 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.common.error.code.UserErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.common.util.ImageUrlConverter;
 import org.orury.domain.comment.domain.CommentStore;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.gym.domain.GymStore;
 import org.orury.domain.post.domain.PostStore;
@@ -14,11 +12,13 @@ import org.orury.domain.review.domain.ReviewStore;
 import org.orury.domain.user.domain.UserReader;
 import org.orury.domain.user.domain.UserStore;
 import org.orury.domain.user.domain.dto.UserDto;
+import org.orury.domain.user.domain.dto.UserStatus;
 import org.orury.domain.user.domain.entity.User;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import static org.orury.common.util.S3Folder.USER;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,37 +26,32 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserServiceImpl implements UserService {
     private final UserReader userReader;
     private final UserStore userStore;
-    private final ImageReader imageReader;
     private final ImageStore imageStore;
     private final PostStore postStore;
     private final CommentStore commentStore;
     private final ReviewStore reviewStore;
     private final GymStore gymStore;
 
-    @Value("${cloud.aws.s3.default-image}")
-    private String defaultImage;
-
     @Override
     @Transactional(readOnly = true)
     public UserDto getUserDtoById(Long id) {
         User user = userReader.findUserById(id)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.NOT_FOUND));
-        var profileLink = imageReader.getUserImageLink(user.getProfileImage());
-        return UserDto.from(user, profileLink);
+        return UserDto.from(user);
     }
 
     @Override
     @Transactional
     public void updateProfileImage(UserDto userDto, MultipartFile image) throws BusinessException {
         //기존에 저장된 요소 삭제
-        imageStore.delete(userDto.profileImage());
+        imageStore.delete(USER, userDto.profileImage());
         imageUploadAndSave(userDto, image);
     }
 
     @Override
     @Transactional
     public void updateUserInfo(UserDto userDto) {
-        userStore.save(userDto.toEntity(ImageUrlConverter.splitUrlToImage(userDto.profileImage())));
+        userStore.save(userDto.toEntity());
     }
 
     @Override
@@ -67,14 +62,20 @@ public class UserServiceImpl implements UserService {
         postStore.deletePostLikesByUserId(userDto.id());
         postStore.deletePostsByUserId(userDto.id());
         reviewStore.deleteReviewReactionsByUserId(userDto.id());
-        imageStore.delete(userDto.profileImage());
-        var deletingUser = userDto.toEntity().delete(defaultImage);
-        userStore.save(deletingUser);
+        var user = userDto.toEntity();
+        user.setStatus(UserStatus.LEAVE);
+        user.setProfileImage(null);
+        imageStore.delete(USER, userDto.profileImage());
+        userStore.save(user);
     }
 
+    /**
+     * 빈 파일이 들어왔는지에 대해서는 upload 메소드에서 유효성 검사해줌.
+     */
     private void imageUploadAndSave(UserDto userDto, MultipartFile file) {
-        // 빈 파일이 들어왔는지에 대해서는 upload 메소드에서 유효성 검사해줌.
-        String image = imageStore.upload(file);
-        userStore.save(userDto.toEntity(image));
+        String image = imageStore.upload(USER, file);
+        var user = userDto.toEntity();
+        user.setProfileImage(image);
+        userStore.save(user);
     }
 }

--- a/orury-client/src/main/resources/application.yml
+++ b/orury-client/src/main/resources/application.yml
@@ -53,7 +53,8 @@ cloud:
     s3:
       bucket: ENC(DWaoEy70NtH+lhLIr08FR4qd/T11UK+X)
       default-image: default-user-profile
-      url: https://s3.ap-northeast-2.amazonaws.com/
+      url: https://d3rzoqirccqyht.cloudfront.net/
+
     credentials:
       accessKey: ENC(yfr+1GPLxMHuTbbID6K7Jbs0Dm9iuuK9yFjrOJv8jCU=)
       secretKey: ENC(nnQ4XTkipeaA+bE6zKD6kI04Axa+E2Qjmw081EgZHpPXhPEBV/dgwqf9YeN1a0vJebMq0yceQJQ=)

--- a/orury-client/src/test/java/org/orury/client/comment/application/CommentServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/comment/application/CommentServiceImplTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.common.error.code.CommentErrorCode;
 import org.orury.common.error.exception.BusinessException;
+import org.orury.common.util.S3Folder;
 import org.orury.domain.comment.domain.CommentReader;
 import org.orury.domain.comment.domain.CommentStore;
 import org.orury.domain.comment.domain.dto.CommentDto;
@@ -149,17 +150,15 @@ class CommentServiceImplTest {
 
         given(commentReader.getCommentsByPostIdAndCursor(postId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE)))
                 .willReturn(comments);
-        given(imageReader.getUserImageLink(anyString()))
+        given(imageReader.getImageLink(any(S3Folder.class), anyString()))
                 .willReturn(profileImage);
 
         // when
         commentService.getCommentDtosByPost(postDto, cursor);
 
         // then
-        then(commentReader).should(times(1))
-                .getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(times(comments.size()))
-                .getUserImageLink(anyString());
+        then(commentReader).should(times(1)).getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
+        then(imageReader).should(times(comments.size())).getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test
@@ -179,8 +178,7 @@ class CommentServiceImplTest {
         // then
         then(commentReader).should(times(1))
                 .getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(never())
-                .getUserImageLink(anyString());
+        then(imageReader).should(never()).getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test
@@ -198,8 +196,7 @@ class CommentServiceImplTest {
 
         given(commentReader.getCommentsByUserIdAndCursor(userId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE)))
                 .willReturn(comments);
-        given(imageReader.getUserImageLink(anyString()))
-                .willReturn(profileImage);
+        given(imageReader.getImageLink(any(S3Folder.class), anyString())).willReturn(profileImage);
 
         // when
         commentService.getCommentDtosByUserId(userId, cursor);
@@ -208,7 +205,7 @@ class CommentServiceImplTest {
         then(commentReader).should(times(1))
                 .getCommentsByUserIdAndCursor(anyLong(), anyLong(), any());
         then(imageReader).should(times(comments.size()))
-                .getUserImageLink(anyString());
+                .getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test
@@ -228,7 +225,7 @@ class CommentServiceImplTest {
         then(commentReader).should(times(1))
                 .getCommentsByUserIdAndCursor(anyLong(), anyLong(), any());
         then(imageReader).should(never())
-                .getUserImageLink(anyString());
+                .getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test

--- a/orury-client/src/test/java/org/orury/client/comment/application/CommentServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/comment/application/CommentServiceImplTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.common.error.code.CommentErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.common.util.S3Folder;
 import org.orury.domain.comment.domain.CommentReader;
 import org.orury.domain.comment.domain.CommentStore;
 import org.orury.domain.comment.domain.dto.CommentDto;
@@ -15,7 +14,6 @@ import org.orury.domain.comment.domain.dto.CommentLikeDto;
 import org.orury.domain.comment.domain.entity.Comment;
 import org.orury.domain.comment.domain.entity.CommentLikePK;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.post.domain.dto.PostDto;
 import org.orury.domain.post.domain.entity.Post;
 import org.orury.domain.user.domain.dto.UserDto;
@@ -44,15 +42,13 @@ class CommentServiceImplTest {
     private CommentService commentService;
     private CommentReader commentReader;
     private CommentStore commentStore;
-    private ImageReader imageReader;
 
     @BeforeEach
     void setUp() {
         commentReader = mock(CommentReader.class);
         commentStore = mock(CommentStore.class);
-        imageReader = mock(ImageReader.class);
 
-        commentService = new CommentServiceImpl(commentReader, commentStore, imageReader);
+        commentService = new CommentServiceImpl(commentReader, commentStore);
     }
 
     @Test
@@ -148,17 +144,12 @@ class CommentServiceImplTest {
                 createComment(3L)
         );
 
-        given(commentReader.getCommentsByPostIdAndCursor(postId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE)))
-                .willReturn(comments);
-        given(imageReader.getImageLink(any(S3Folder.class), anyString()))
-                .willReturn(profileImage);
-
+        given(commentReader.getCommentsByPostIdAndCursor(postId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE))).willReturn(comments);
         // when
         commentService.getCommentDtosByPost(postDto, cursor);
 
         // then
         then(commentReader).should(times(1)).getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(times(comments.size())).getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test
@@ -169,16 +160,13 @@ class CommentServiceImplTest {
         PostDto postDto = createPostDto(postId);
         Long cursor = 22L;
 
-        given(commentReader.getCommentsByPostIdAndCursor(postId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE)))
-                .willReturn(Collections.emptyList());
+        given(commentReader.getCommentsByPostIdAndCursor(postId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE))).willReturn(Collections.emptyList());
 
         // when
         commentService.getCommentDtosByPost(postDto, cursor);
 
         // then
-        then(commentReader).should(times(1))
-                .getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(never()).getImageLink(any(S3Folder.class), anyString());
+        then(commentReader).should(times(1)).getCommentsByPostIdAndCursor(anyLong(), anyLong(), any());
     }
 
     @Test
@@ -194,9 +182,7 @@ class CommentServiceImplTest {
                 createComment(3L)
         );
 
-        given(commentReader.getCommentsByUserIdAndCursor(userId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE)))
-                .willReturn(comments);
-        given(imageReader.getImageLink(any(S3Folder.class), anyString())).willReturn(profileImage);
+        given(commentReader.getCommentsByUserIdAndCursor(userId, cursor, PageRequest.of(0, NumberConstants.COMMENT_PAGINATION_SIZE))).willReturn(comments);
 
         // when
         commentService.getCommentDtosByUserId(userId, cursor);
@@ -204,8 +190,6 @@ class CommentServiceImplTest {
         // then
         then(commentReader).should(times(1))
                 .getCommentsByUserIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(times(comments.size()))
-                .getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test
@@ -224,8 +208,6 @@ class CommentServiceImplTest {
         // then
         then(commentReader).should(times(1))
                 .getCommentsByUserIdAndCursor(anyLong(), anyLong(), any());
-        then(imageReader).should(never())
-                .getImageLink(any(S3Folder.class), anyString());
     }
 
     @Test

--- a/orury-client/src/test/java/org/orury/client/gym/application/GymServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/gym/application/GymServiceImplTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.common.error.code.GymErrorCode;
 import org.orury.common.error.exception.BusinessException;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.gym.domain.GymReader;
 import org.orury.domain.gym.domain.GymStore;
 import org.orury.domain.gym.domain.dto.GymDto;
@@ -28,7 +27,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
-import static org.orury.common.util.S3Folder.GYM;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[Service] 암장 ServiceImpl 테스트")
@@ -38,15 +36,13 @@ class GymServiceImplTest {
     GymService gymService;
     GymReader gymReader;
     GymStore gymStore;
-    ImageReader imageReader;
 
     @BeforeEach
     void setUp() {
         gymReader = mock(GymReader.class);
         gymStore = mock(GymStore.class);
-        imageReader = mock(ImageReader.class);
 
-        gymService = new GymServiceImpl(gymReader, gymStore, imageReader);
+        gymService = new GymServiceImpl(gymReader, gymStore);
     }
 
     @Test
@@ -54,26 +50,19 @@ class GymServiceImplTest {
     void should_RetrieveGymDtoById() {
         // given
         Long gymId = 1L;
-        Gym gym = createGym(gymId);
-        List<String> images = List.of("image1", "image2", "image3");
+        GymDto expect = createGymDto();
+        Gym gym = expect.toEntity();
 
-        given(gymReader.findGymById(gymId))
-                .willReturn(Optional.of(gym));
-        given(imageReader.getImageLinks(GYM, gym.getImages()))
-                .willReturn(images);
-
-        GymDto expectedGymDto = GymDto.from(gym, images);
+        given(gymReader.findGymById(any())).willReturn(Optional.of(gym));
 
         // when
-        GymDto actualGymDto = gymService.getGymDtoById(gymId);
+        GymDto actual = gymService.getGymDtoById(gymId);
 
         // then
-        assertEquals(expectedGymDto, actualGymDto);
+        assertEquals(expect, actual);
 
         then(gymReader).should(times(1))
                 .findGymById(anyLong());
-        then(imageReader).should(times(1))
-                .getImageLinks(any(), any());
     }
 
     @Test
@@ -91,8 +80,6 @@ class GymServiceImplTest {
 
         then(gymReader).should(times(1))
                 .findGymById(anyLong());
-        then(imageReader).should(never())
-                .getImageLinks(any(), any());
     }
 
     @Test
@@ -526,6 +513,37 @@ class GymServiceImplTest {
                 businessHour,
                 businessHour,
                 businessHour,
+                "gymHomepageLink",
+                "gymRemark"
+        );
+    }
+
+    private GymDto createGymDto() {
+        return GymDto.of(
+                1L,
+                "더클라임 봉은사점",
+                "kakaoid",
+                "서울시 도로명주소",
+                "서울시 지번주소",
+                40.5f,
+                23,
+                12,
+                List.of(),
+                37.513709,
+                127.062144,
+                "더클라임",
+                "01012345678",
+                "gymInstagramLink.com",
+                "MONDAY",
+                null,
+                null,
+                "businessHour",
+                "businessHour",
+                "businessHour",
+                "businessHour",
+                "businessHour",
+                "businessHour",
+                "businessHour",
                 "gymHomepageLink",
                 "gymRemark"
         );

--- a/orury-client/src/test/java/org/orury/client/post/service/PostServiceTest.java
+++ b/orury-client/src/test/java/org/orury/client/post/service/PostServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.client.post.application.PostServiceImpl;
 import org.orury.common.error.exception.BusinessException;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.post.domain.PostReader;
 import org.orury.domain.post.domain.PostStore;
@@ -51,7 +50,6 @@ import static org.orury.domain.global.constants.NumberConstants.USER_ID;
 class PostServiceTest {
     private PostReader postReader;
     private PostStore postStore;
-    private ImageReader imageReader;
     private ImageStore imageStore;
     private PostServiceImpl postService;
 
@@ -59,9 +57,8 @@ class PostServiceTest {
     public void setUp() {
         postReader = mock(PostReader.class);
         postStore = mock(PostStore.class);
-        imageReader = mock(ImageReader.class);
         imageStore = mock(ImageStore.class);
-        postService = new PostServiceImpl(postReader, postStore, imageReader, imageStore);
+        postService = new PostServiceImpl(postReader, postStore, imageStore);
     }
 
     @Test
@@ -195,8 +192,6 @@ class PostServiceTest {
 
         given(postReader.findById(1L)).willReturn(Optional.of(post));
         given(postReader.isPostLiked(any(), any())).willReturn(false);
-        given(imageReader.getImageLinks(any(), any())).willReturn(post.getImages());
-        given(imageReader.getUserImageLink(any())).willReturn(userImage);
 
         // when
         var actual = postService.getPostDtoById(1L);
@@ -284,8 +279,6 @@ class PostServiceTest {
         String userImage = "test.png";
 
         when(postReader.findByCategoryOrderByIdDesc(category, cursor, pageable)).thenReturn(posts);
-        when(imageReader.getImageLinks(POST, postImages)).thenReturn(postImages);
-        when(imageReader.getUserImageLink(userImage)).thenReturn(userImage);
 
         // when
         List<PostDto> resultPostDtos = postService.getPostDtosByCategory(category, cursor, PageRequest.of(0, 10));
@@ -331,7 +324,6 @@ class PostServiceTest {
         List<String> postImages = List.of("post1.png", "post2.png");
 
         when(postReader.findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, cursor, pageable)).thenReturn(posts);
-        when(imageReader.getImageLinks(POST, postImages)).thenReturn(postImages);
 
         // when
         List<PostDto> resultPostDtos = postService.getPostDtosBySearchWord(searchWord, cursor, PageRequest.of(0, 10));
@@ -359,14 +351,12 @@ class PostServiceTest {
         );
         List<String> postImages = List.of("post1.png", "post2.png");
 
-        given(imageReader.getImageLinks(POST, postImages)).willReturn(postImages);
         when(postReader.findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, cursor, pageable)).thenReturn(posts);
 
         // when
         List<PostDto> resultPostDtos = postService.getPostDtosBySearchWord(searchWord, cursor, PageRequest.of(0, 10));
 
         // then
-        then(imageReader).should(times(2)).getImageLinks(POST, postImages);
         verify(postReader).findByTitleContainingOrContentContainingOrderByIdDesc(searchWord, cursor, pageable);
         assertEquals(postDtos.size(), resultPostDtos.size());
     }
@@ -394,19 +384,16 @@ class PostServiceTest {
         List<String> postImages = List.of("post1.png", "post2.png");
         String userImage = "test.png";
         List<PostDto> expectPostDtos = posts.stream()
-                .map(post -> PostDto.from(post, postImages, userImage, false))
+                .map(post -> PostDto.from(post, false))
                 .toList();
 
         given(postReader.findByUserIdOrderByIdDesc(anyLong(), anyLong(), any())).willReturn(posts);
-        given(imageReader.getImageLinks(any(), any())).willReturn(postImages);
-        given(imageReader.getUserImageLink(any())).willReturn(userImage);
 
         // when
         List<PostDto> resultPostDtos = postService.getPostDtosByUserId(USER_ID, cursor, pageable);
 
         // then
         assertEquals(resultPostDtos, expectPostDtos);
-        then(imageReader).should(times(10)).getImageLinks(any(), any());
         then(postReader).should(times(1)).findByUserIdOrderByIdDesc(anyLong(), anyLong(), any());
     }
 
@@ -431,13 +418,15 @@ class PostServiceTest {
         );
         List<String> postImages = List.of("post1.png", "post2.png");
         String userImage = "test.png";
+//        List<PostDto> expectPostDtos = posts.stream()
+//                .map(post -> PostDto.from(post, postImages, userImage, false))
+//                .toList();
+
         List<PostDto> expectPostDtos = posts.stream()
-                .map(post -> PostDto.from(post, postImages, userImage, false))
+                .map(post -> PostDto.from(post, false))
                 .toList();
 
         given(postReader.findByUserIdOrderByIdDesc(anyLong(), anyLong(), any())).willReturn(posts);
-        given(imageReader.getImageLinks(any(), any())).willReturn(postImages);
-        given(imageReader.getUserImageLink(any())).willReturn(userImage);
 
         // when
         List<PostDto> resultPostDtos = postService.getPostDtosByUserId(USER_ID, cursor, pageable);

--- a/orury-client/src/test/java/org/orury/client/review/application/ReviewServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/review/application/ReviewServiceImplTest.java
@@ -9,7 +9,6 @@ import org.orury.common.error.code.ReviewErrorCode;
 import org.orury.common.error.exception.BusinessException;
 import org.orury.common.util.S3Folder;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.image.ImageReader;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.gym.domain.GymStore;
 import org.orury.domain.gym.domain.dto.GymDto;
@@ -31,7 +30,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,7 +46,6 @@ class ReviewServiceImplTest {
     private ReviewReader reviewReader;
     private ReviewStore reviewStore;
     private GymStore gymStore;
-    private ImageReader imageReader;
     private ImageStore imageStore;
 
     private ReviewService reviewService;
@@ -58,9 +55,8 @@ class ReviewServiceImplTest {
         reviewReader = mock(ReviewReader.class);
         reviewStore = mock(ReviewStore.class);
         gymStore = mock(GymStore.class);
-        imageReader = mock(ImageReader.class);
         imageStore = mock(ImageStore.class);
-        reviewService = new ReviewServiceImpl(reviewReader, reviewStore, gymStore, imageReader, imageStore);
+        reviewService = new ReviewServiceImpl(reviewReader, reviewStore, gymStore, imageStore);
 
     }
 
@@ -103,7 +99,7 @@ class ReviewServiceImplTest {
         then(gymStore).should(times(1))
                 .updateTotalScore(beforeReviewDto.id(), beforeReviewDto.score(), updateReviewDto.score());
         then(imageStore).should(times(1))
-                .oldS3ImagesDelete(S3Folder.REVIEW.getName(), beforeReviewDto.images());
+                .delete(S3Folder.REVIEW, beforeReviewDto.images());
     }
 
     @DisplayName("리뷰 ID를 통해 리뷰 DTO를 반환한다.")
@@ -118,7 +114,6 @@ class ReviewServiceImplTest {
         Review review = createReview(reviewId, userId, gymId);
 
         given(reviewReader.findById(reviewId)).willReturn(Optional.of(review));
-        given(imageReader.getImageLinks(S3Folder.REVIEW, review.getImages())).willReturn(Collections.singletonList(urls));
 
         // when
         reviewService.getReviewDtoById(reviewId, userId);
@@ -126,8 +121,6 @@ class ReviewServiceImplTest {
         // then
         then(reviewReader).should(times(1))
                 .findById(anyLong());
-        then(imageReader).should(times(1))
-                .getImageLinks(any(), anyList());
     }
 
     @DisplayName("리뷰 Dto를 받아 리뷰를 성공적으로 삭제한다.")
@@ -149,7 +142,7 @@ class ReviewServiceImplTest {
         then(reviewStore).should(times(1))
                 .delete(reviewDto.toEntity());
         then(imageStore).should(times(1))
-                .oldS3ImagesDelete(S3Folder.REVIEW.getName(), reviewDto.images());
+                .delete(S3Folder.REVIEW, reviewDto.images());
     }
 
     @DisplayName("존재하지 않는 리뷰를 검색 시, NOT_FOUND exception을 발생시킨다.")

--- a/orury-common/src/main/java/org/orury/common/config/BeanUtils.java
+++ b/orury-common/src/main/java/org/orury/common/config/BeanUtils.java
@@ -1,0 +1,23 @@
+package org.orury.common.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BeanUtils implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(@NotNull ApplicationContext applicationContext) throws BeansException {
+        BeanUtils.applicationContext = applicationContext;
+    }
+
+    public static <T> T getBean(Class<T> cls) {
+        return applicationContext.getBean(cls);
+    }
+
+}

--- a/orury-common/src/main/java/org/orury/common/util/ImageUtil.java
+++ b/orury-common/src/main/java/org/orury/common/util/ImageUtil.java
@@ -1,6 +1,5 @@
 package org.orury.common.util;
 
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
@@ -31,7 +30,7 @@ public class ImageUtil {
     }
 
     public static String splitUrlToImage(String url) {
-        if (Objects.isNull(url) || url.isEmpty()) return Strings.EMPTY;
+        if (Objects.isNull(url) || url.isEmpty()) return null;
         return Arrays.stream(url.split("/"))
                 .reduce((first, second) -> second)
                 .orElse("");

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/Crew.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/Crew.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
+import org.orury.domain.global.listener.CrewImageConverter;
 import org.orury.domain.user.domain.entity.User;
 
 import java.time.LocalDateTime;
@@ -35,6 +36,7 @@ public class Crew extends AuditingField {
     @Column(name = "description", nullable = true)
     private String description;
 
+    @Convert(converter = CrewImageConverter.class)
     @Column(name = "icon", nullable = true)
     private String icon;
 

--- a/orury-domain/src/main/java/org/orury/domain/global/image/ImageReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/image/ImageReader.java
@@ -5,7 +5,7 @@ import org.orury.common.util.S3Folder;
 import java.util.List;
 
 public interface ImageReader {
-    String getUserImageLink(String profile);
+    String getImageLink(S3Folder domain, String profile);
 
     List<String> getImageLinks(S3Folder domain, List<String> images);
 }

--- a/orury-domain/src/main/java/org/orury/domain/global/image/ImageStore.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/image/ImageStore.java
@@ -8,11 +8,11 @@ import java.util.List;
 public interface ImageStore {
     List<String> upload(S3Folder domain, List<MultipartFile> files);
 
-    String upload(MultipartFile profile);
+    String upload(S3Folder domain, MultipartFile image);
 
     void delete(S3Folder domain, List<String> imageLinks);
 
-    void delete(String profile);
+    void delete(S3Folder domain, String profile);
 
     void oldS3ImagesDelete(String domain, List<String> images);
 }

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/CrewImageConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/CrewImageConverter.java
@@ -1,9 +1,11 @@
 package org.orury.domain.global.listener;
 
-// TODO 크루 적용되면 주석풀고 사용하시면 됩니다.
-//public class CrewImageConverter extends EntityImageConverter {
-//    @Override
-//    protected S3Folder domainName() {
-//        return S3Folder.CREW;
-//    }
-//}
+
+import org.orury.common.util.S3Folder;
+
+public class CrewImageConverter extends EntityImageConverter {
+    @Override
+    protected S3Folder domainName() {
+        return S3Folder.CREW;
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/CrewImageConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/CrewImageConverter.java
@@ -1,0 +1,9 @@
+package org.orury.domain.global.listener;
+
+// TODO 크루 적용되면 주석풀고 사용하시면 됩니다.
+//public class CrewImageConverter extends EntityImageConverter {
+//    @Override
+//    protected S3Folder domainName() {
+//        return S3Folder.CREW;
+//    }
+//}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/EntityImagesConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/EntityImagesConverter.java
@@ -1,0 +1,45 @@
+package org.orury.domain.global.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.commons.lang3.StringUtils;
+import org.orury.common.config.BeanUtils;
+import org.orury.common.error.code.FileExceptionCode;
+import org.orury.common.error.exception.InfraImplException;
+import org.orury.common.util.ImageUtil;
+import org.orury.common.util.S3Folder;
+import org.orury.domain.global.image.ImageReader;
+
+import java.util.List;
+
+@Converter
+public abstract class EntityImagesConverter implements AttributeConverter<List<String>, String> {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    abstract protected S3Folder domainName();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (ImageUtil.imagesValidation(attribute)) return null;
+        try {
+            var images = attribute.stream().map(ImageUtil::splitUrlToImage).toArray();
+            return mapper.writeValueAsString(images);
+        } catch (JsonProcessingException e) {
+            throw new InfraImplException(FileExceptionCode.FILE_DOWNLOAD_ERROR);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (StringUtils.isBlank(dbData)) return null;
+        var imageReader = BeanUtils.getBean(ImageReader.class);
+        try {
+            List<String> images = mapper.readValue(dbData, List.class);
+            return imageReader.getImageLinks(domainName(), images);
+        } catch (JsonProcessingException e) {
+            throw new InfraImplException(FileExceptionCode.FILE_UPLOAD_ERROR);
+        }
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/GymImagesConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/GymImagesConverter.java
@@ -1,0 +1,10 @@
+package org.orury.domain.global.listener;
+
+import org.orury.common.util.S3Folder;
+
+public class GymImagesConverter extends EntityImagesConverter {
+    @Override
+    protected S3Folder domainName() {
+        return S3Folder.GYM;
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/PostImagesConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/PostImagesConverter.java
@@ -1,0 +1,10 @@
+package org.orury.domain.global.listener;
+
+import org.orury.common.util.S3Folder;
+
+public class PostImagesConverter extends EntityImagesConverter {
+    @Override
+    protected S3Folder domainName() {
+        return S3Folder.POST;
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/ReviewImagesConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/ReviewImagesConverter.java
@@ -1,0 +1,10 @@
+package org.orury.domain.global.listener;
+
+import org.orury.common.util.S3Folder;
+
+public class ReviewImagesConverter extends EntityImagesConverter {
+    @Override
+    protected S3Folder domainName() {
+        return S3Folder.REVIEW;
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/global/listener/UserProfileConverter.java
+++ b/orury-domain/src/main/java/org/orury/domain/global/listener/UserProfileConverter.java
@@ -1,0 +1,12 @@
+package org.orury.domain.global.listener;
+
+import jakarta.persistence.Converter;
+import org.orury.common.util.S3Folder;
+
+@Converter
+public class UserProfileConverter extends EntityImageConverter {
+    @Override
+    protected S3Folder domainName() {
+        return S3Folder.USER;
+    }
+}

--- a/orury-domain/src/main/java/org/orury/domain/gym/domain/entity/Gym.java
+++ b/orury-domain/src/main/java/org/orury/domain/gym/domain/entity/Gym.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
-import org.orury.domain.global.listener.EntityImageConverter;
+import org.orury.domain.global.listener.GymImagesConverter;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class Gym extends AuditingField {
     @Column(name = "like_count")
     private int likeCount;
 
-    @Convert(converter = EntityImageConverter.class)
+    @Convert(converter = GymImagesConverter.class)
     @Column(name = "images")
     private List<String> images;
 

--- a/orury-domain/src/main/java/org/orury/domain/post/domain/dto/PostDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/post/domain/dto/PostDto.java
@@ -57,16 +57,12 @@ public record PostDto(
     public static PostDto from(Post entity) {
         return PostDto.from(
                 entity,
-                entity.getImages(),
-                entity.getUser().getProfileImage(),
                 false
         );
     }
 
     public static PostDto from(
             Post entity,
-            List<String> links,
-            String profileLink,
             boolean isLike
     ) {
         return new PostDto(
@@ -76,9 +72,9 @@ public record PostDto(
                 entity.getViewCount(),
                 entity.getCommentCount(),
                 entity.getLikeCount(),
-                links,
+                entity.getImages(),
                 entity.getCategory(),
-                UserDto.from(entity.getUser(), profileLink),
+                UserDto.from(entity.getUser()),
                 isLike,
                 entity.getCreatedAt(),
                 entity.getUpdatedAt()

--- a/orury-domain/src/main/java/org/orury/domain/post/domain/entity/Post.java
+++ b/orury-domain/src/main/java/org/orury/domain/post/domain/entity/Post.java
@@ -4,10 +4,11 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
-import org.orury.domain.global.listener.EntityImageConverter;
+import org.orury.domain.global.listener.PostImagesConverter;
 import org.orury.domain.user.domain.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -37,9 +38,9 @@ public class Post extends AuditingField {
     @Column(name = "like_count", nullable = false)
     private int likeCount;
 
-    @Convert(converter = EntityImageConverter.class)
+    @Convert(converter = PostImagesConverter.class)
     @Column(name = "images")
-    private List<String> images;
+    private List<String> images = new ArrayList<>();
 
     @Column(name = "category", nullable = false)
     private int category;

--- a/orury-domain/src/main/java/org/orury/domain/post/infrastructure/ImageReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/post/infrastructure/ImageReaderImpl.java
@@ -1,6 +1,5 @@
 package org.orury.domain.post.infrastructure;
 
-import com.amazonaws.services.s3.AmazonS3;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -17,17 +16,15 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class ImageReaderImpl implements ImageReader {
-    private final AmazonS3 amazonS3;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
     @Value("${cloud.aws.s3.default-image}")
-    private String defaultImage;
+    private String DEFAULT_IMAGE;
+
+    @Value("${cloud.aws.s3.url}")
+    private String URL;
 
     @Override
     public String getImageLink(S3Folder domain, String profile) {
-        if (S3Folder.USER == domain && StringUtils.isBlank(profile)) profile = defaultImage;
+        if (S3Folder.USER == domain && StringUtils.isBlank(profile)) profile = DEFAULT_IMAGE;
 //        if (S3Folder.CREW==domain && StringUtils.isBlank(profile)) profile =  defaultImage;
         return getUrls(domain, List.of(profile)).get(0);
     }
@@ -40,7 +37,7 @@ public class ImageReaderImpl implements ImageReader {
     private List<String> getUrls(S3Folder domain, List<String> images) {
         try {
             return images.stream()
-                    .map(it -> amazonS3.getUrl(bucket + domain.getName(), it).toString())
+                    .map(it -> URL + domain.getName() + "/" + it)
                     .toList();
         } catch (Exception e) {
             throw new InfraImplException(FileExceptionCode.FILE_NOT_FOUND);

--- a/orury-domain/src/main/java/org/orury/domain/post/infrastructure/ImageReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/post/infrastructure/ImageReaderImpl.java
@@ -22,10 +22,13 @@ public class ImageReaderImpl implements ImageReader {
     @Value("${cloud.aws.s3.url}")
     private String URL;
 
+    /**
+     * 추후에 유저, 크루의 기본 이미지 변경될 수 있어 나눠둠
+     */
     @Override
     public String getImageLink(S3Folder domain, String profile) {
         if (S3Folder.USER == domain && StringUtils.isBlank(profile)) profile = DEFAULT_IMAGE;
-//        if (S3Folder.CREW==domain && StringUtils.isBlank(profile)) profile =  defaultImage;
+        if (S3Folder.CREW == domain && StringUtils.isBlank(profile)) profile = DEFAULT_IMAGE;
         return getUrls(domain, List.of(profile)).get(0);
     }
 

--- a/orury-domain/src/main/java/org/orury/domain/review/domain/entity/Review.java
+++ b/orury-domain/src/main/java/org/orury/domain/review/domain/entity/Review.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
-import org.orury.domain.global.listener.EntityImageConverter;
+import org.orury.domain.global.listener.ReviewImagesConverter;
 import org.orury.domain.gym.domain.entity.Gym;
 import org.orury.domain.user.domain.entity.User;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -32,7 +32,7 @@ public class Review extends AuditingField {
     @Column(name = "content")
     private String content;
 
-    @Convert(converter = EntityImageConverter.class)
+    @Convert(converter = ReviewImagesConverter.class)
     @Column(name = "images")
     private List<String> images;
 

--- a/orury-domain/src/main/java/org/orury/domain/user/domain/dto/UserDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/user/domain/dto/UserDto.java
@@ -65,7 +65,7 @@ public record UserDto(
         );
     }
 
-    public static UserDto from(User entity, String imageUrl) {
+    public static UserDto from(User entity, String profileImage) {
         return UserDto.of(
                 entity.getId(),
                 entity.getEmail(),
@@ -74,7 +74,7 @@ public record UserDto(
                 entity.getSignUpType(),
                 entity.getGender(),
                 entity.getBirthday(),
-                imageUrl,
+                profileImage,
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
                 entity.getStatus()

--- a/orury-domain/src/main/java/org/orury/domain/user/domain/entity/User.java
+++ b/orury-domain/src/main/java/org/orury/domain/user/domain/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
+import org.orury.domain.global.listener.UserProfileConverter;
 import org.orury.domain.user.domain.dto.UserStatus;
 import org.orury.domain.user.domain.dto.UserStatusConverter;
 
@@ -40,9 +41,12 @@ public class User extends AuditingField {
     @Column(name = "birthday", nullable = false)
     private LocalDate birthday;
 
+    @Setter
+    @Convert(converter = UserProfileConverter.class)
     @Column(name = "profile_image")
     private String profileImage;
 
+    @Setter
     @Column(name = "status")
     @Convert(converter = UserStatusConverter.class)
     private UserStatus status;
@@ -63,11 +67,5 @@ public class User extends AuditingField {
 
     public static User of(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt, UserStatus status) {
         return new User(id, email, nickname, password, signUpType, gender, birthday, profileImage, createdAt, updatedAt, status);
-    }
-
-    public User delete(String defaultImage) {
-        this.profileImage = defaultImage;
-        this.status = UserStatus.LEAVE;
-        return this;
     }
 }


### PR DESCRIPTION
## 개요

### 이미지 처리
각 Entity에서 image는 ImageConverter를 사용

- DB -> Entity : S3의 각 버킷에 저장된 링크가 반환
- Entity -> DB : 링크를 알아서 파싱하여 저장
- 이미지가 없는 경우 null을 저장하게 됨, 따라서 해당 PR이 머지되면 DB이미지 -> [ ] 되어있는건 전부 null 처리 필요

### BeanUtils

Converter, EntityListener에 빈을 주입하지 못함 이유는 모르겠지만 flyway에러뜸
그래서 BeanUtils로 static하게 가져다가 씀

### CDN 적용

- CloudFront 사용하여 ImageReader 부분은 성능이 개선된듯? 좀 빠름

### 논의 사항

Entity의 수정사항을 반영할때  of, toEntity를 계속 사용하는게 맞다 vs 변경이 필요한 이미지, 유저상태값은 Setter를 써도 된다.
맛보기로 유저의 이미지와 상태 변경을 Setter를 사용함 -> UserServiceImpl


closed #349

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
