### PR TITLE
Feat : 테스트코드 Fixture 생성 메서드 통합 (w/ Object Mother 패턴, Test Fixtures 플러그인)

### DIFF
--- a/orury-client/build.gradle
+++ b/orury-client/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation project(':orury-common')
     implementation project(':orury-domain')
 
+    //test fixtures
+    testImplementation(testFixtures(project(':orury-domain')))
+
     //devtools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
@@ -29,7 +29,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,6 +38,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 import static org.orury.domain.DomainFixtureFactory.TestCrew.createCrew;
 import static org.orury.domain.DomainFixtureFactory.TestCrewDto.createCrewDto;
+import static org.orury.domain.DomainFixtureFactory.TestCrewMemberPK.createCrewMemberPK;
 import static org.orury.domain.DomainFixtureFactory.TestUserDto.createUserDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -871,11 +871,11 @@ class CrewServiceImplTest {
     }
 
     private CrewMember createCrewMember(Long crewId, Long userId) {
-        return CrewMember.of(
-                CrewMemberPK.of(userId, crewId),
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
+        CrewMemberPK crewMemberPK = createCrewMemberPK()
+                .crewId(crewId)
+                .userId(userId).build().get();
+        return DomainFixtureFactory.TestCrewMember.createCrewMember()
+                .crewMemberPK(crewMemberPK).build().get();
     }
 
     private User createUser(Long userId) {

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
@@ -22,7 +22,6 @@ import org.orury.domain.meeting.domain.MeetingMemberStore;
 import org.orury.domain.meeting.domain.MeetingStore;
 import org.orury.domain.user.domain.UserReader;
 import org.orury.domain.user.domain.dto.UserDto;
-import org.orury.domain.user.domain.entity.User;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
@@ -38,7 +37,8 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 import static org.orury.domain.DomainFixtureFactory.TestCrew.createCrew;
 import static org.orury.domain.DomainFixtureFactory.TestCrewDto.createCrewDto;
-import static org.orury.domain.DomainFixtureFactory.TestCrewMemberPK.createCrewMemberPK;
+import static org.orury.domain.DomainFixtureFactory.TestCrewMember.createCrewMember;
+import static org.orury.domain.DomainFixtureFactory.TestUser.createUser;
 import static org.orury.domain.DomainFixtureFactory.TestUserDto.createUserDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -237,14 +237,18 @@ class CrewServiceImplTest {
         // given
         CrewDto crewDto = createCrewDto().build().get();
         List<CrewMember> otherMembers = List.of(
-                createCrewMember(crewDto.id(), 1L),
-                createCrewMember(crewDto.id(), 2L),
-                createCrewMember(crewDto.id(), 3L)
+                createCrewMember(crewDto.id(), 1L).build().get(),
+                createCrewMember(crewDto.id(), 2L).build().get(),
+                createCrewMember(crewDto.id(), 3L).build().get()
         );
         given(crewMemberReader.getOtherCrewMembersByCrewIdMaximum(anyLong(), anyLong(), anyInt()))
                 .willReturn(otherMembers);
         given(userReader.getUserById(anyLong()))
-                .willReturn(createUser(1L), createUser(2L), createUser(3L));
+                .willReturn(
+                        createUser(1L).build().get(),
+                        createUser(2L).build().get(),
+                        createUser(3L).build().get()
+                );
 
         // when
         List<String> userImages = crewService.getUserImagesByCrew(crewDto);
@@ -868,18 +872,5 @@ class CrewServiceImplTest {
         then(meetingMemberStore).shouldHaveNoInteractions();
         then(meetingStore).shouldHaveNoInteractions();
         then(crewMemberStore).shouldHaveNoInteractions();
-    }
-
-    private CrewMember createCrewMember(Long crewId, Long userId) {
-        CrewMemberPK crewMemberPK = createCrewMemberPK()
-                .crewId(crewId)
-                .userId(userId).build().get();
-        return DomainFixtureFactory.TestCrewMember.createCrewMember()
-                .crewMemberPK(crewMemberPK).build().get();
-    }
-
-    private User createUser(Long userId) {
-        return DomainFixtureFactory.TestUser.createUser()
-                .id(userId).build().get();
     }
 }

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
@@ -13,18 +13,15 @@ import org.orury.domain.DomainFixtureFactory;
 import org.orury.domain.crew.domain.*;
 import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
-import org.orury.domain.crew.domain.dto.CrewStatus;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.orury.domain.crew.domain.entity.CrewMemberPK;
 import org.orury.domain.global.constants.NumberConstants;
-import org.orury.domain.global.domain.Region;
 import org.orury.domain.global.image.ImageStore;
 import org.orury.domain.meeting.domain.MeetingMemberStore;
 import org.orury.domain.meeting.domain.MeetingStore;
 import org.orury.domain.user.domain.UserReader;
 import org.orury.domain.user.domain.dto.UserDto;
-import org.orury.domain.user.domain.dto.UserStatus;
 import org.orury.domain.user.domain.entity.User;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +30,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +37,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
+import static org.orury.domain.DomainFixtureFactory.TestCrew.createCrew;
+import static org.orury.domain.DomainFixtureFactory.TestCrewDto.createCrewDto;
+import static org.orury.domain.DomainFixtureFactory.TestUserDto.createUserDto;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[Service] 크루 ServiceImpl 테스트")
@@ -85,7 +84,8 @@ class CrewServiceImplTest {
     void should_GetCrewDtoById() {
         // given
         Long crewId = 1L;
-        Crew crew = createCrew(crewId);
+        Crew crew = createCrew()
+                .id(crewId).build().get();
         List<String> tags = List.of("태그1", "태그2", "태그3");
         given(crewReader.findById(crewId))
                 .willReturn(Optional.of(crew));
@@ -124,7 +124,7 @@ class CrewServiceImplTest {
     @Test
     void should_CreateCrew() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         MultipartFile file = mock(MultipartFile.class);
         int participatingCrewCount = 2;
         int applyingCrewCount = 1;
@@ -135,7 +135,8 @@ class CrewServiceImplTest {
         String icon = "크루아이콘";
         given(imageAsyncStore.upload(S3Folder.CREW, file))
                 .willReturn(icon);
-        Crew crew = createCrew(crewDto.id());
+        Crew crew = createCrew()
+                .id(crewDto.id()).build().get();
         given(crewStore.save(any()))
                 .willReturn(crew);
 
@@ -157,7 +158,7 @@ class CrewServiceImplTest {
     @Test
     void when_OverMaximumParticipation_Then_MaximumParticipationException() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         MultipartFile file = mock(MultipartFile.class);
         int participatingCrewCount = 2;
         int applyingCrewCount = 3;
@@ -234,7 +235,7 @@ class CrewServiceImplTest {
     @Test
     void should_GetUserImagesByCrew() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         List<CrewMember> otherMembers = List.of(
                 createCrewMember(crewDto.id(), 1L),
                 createCrewMember(crewDto.id(), 2L),
@@ -283,7 +284,7 @@ class CrewServiceImplTest {
     @Test
     void should_UpdateCrewImage() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         MultipartFile file = mock(MultipartFile.class);
         Long userId = crewDto.userDto().id();
         String newImage = "크루아이콘";
@@ -306,7 +307,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotCrewCreator_Then_ForbiddenException1() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         MultipartFile file = mock(MultipartFile.class);
         Long userId = 2134L;
 
@@ -324,7 +325,7 @@ class CrewServiceImplTest {
     @Test
     void should_DeleteCrew() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = crewDto.userDto().id();
 
         // when
@@ -341,7 +342,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotCrewCreator_Then_ForbiddenException2() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = 284L;
 
         // when & then
@@ -355,20 +356,18 @@ class CrewServiceImplTest {
 
     @DisplayName("[applyCrew] 크루에 가입신청을 한다.")
     @Test
-    void should_ApplyCrew() throws NoSuchFieldException, IllegalAccessException {
+    void should_ApplyCrew() {
         // given
-        CrewDto crewDto = createCrewDto(List.of(
-                "id", 23L,
-                "minAge", 15,
-                "maxAge", 30,
-                "gender", CrewGender.ANY,
-                "permissionRequired", true,
-                "answerRequired", true
-        ));
-        UserDto userDto = createUserDto(List.of(
-                "gender", NumberConstants.MALE,
-                "birthday", LocalDate.now().minusYears(20)
-        ));
+        CrewDto crewDto = createCrewDto()
+                .id(23L)
+                .minAge(15)
+                .maxAge(30)
+                .gender(CrewGender.ANY)
+                .permissionRequired(true)
+                .answerRequired(true).build().get();
+        UserDto userDto = createUserDto()
+                .gender(NumberConstants.MALE)
+                .birthday(LocalDate.now().minusYears(20)).build().get();
 
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
@@ -397,8 +396,8 @@ class CrewServiceImplTest {
     @Test
     void when_AlreadyMember_Then_AlreadyMemberException() {
         // given
-        CrewDto crewDto = createCrewDto();
-        UserDto userDto = createUserDto();
+        CrewDto crewDto = createCrewDto().build().get();
+        UserDto userDto = createUserDto().build().get();
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
                 .willReturn(true);
@@ -421,8 +420,8 @@ class CrewServiceImplTest {
     @Test
     void when_OverMaximumParticipation_Then_MaximumParticipationException1() {
         // given
-        CrewDto crewDto = createCrewDto();
-        UserDto userDto = createUserDto();
+        CrewDto crewDto = createCrewDto().build().get();
+        UserDto userDto = createUserDto().build().get();
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
                 .willReturn(false);
@@ -450,14 +449,12 @@ class CrewServiceImplTest {
     @Test
     void when_AgeForbidden_Then_AgeForbiddenException() {
         // given
-        CrewDto crewDto = createCrewDto(List.of(
-                "id", 23L,
-                "minAge", 15,
-                "maxAge", 30
-        ));
-        UserDto userDto = createUserDto(List.of(
-                "birthday", LocalDate.now().minusYears(14)
-        ));
+        CrewDto crewDto = createCrewDto()
+                .id(23L)
+                .minAge(15)
+                .maxAge(30).build().get();
+        UserDto userDto = createUserDto()
+                .birthday(LocalDate.now().minusYears(14)).build().get();
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
                 .willReturn(false);
@@ -485,12 +482,10 @@ class CrewServiceImplTest {
     @Test
     void when_GenderForbidden_Then_GenderForbiddenException() {
         // given
-        CrewDto crewDto = createCrewDto(List.of(
-                "gender", CrewGender.FEMALE
-        ));
-        UserDto userDto = createUserDto(List.of(
-                "gender", NumberConstants.MALE
-        ));
+        CrewDto crewDto = createCrewDto()
+                .gender(CrewGender.FEMALE).build().get();
+        UserDto userDto = createUserDto()
+                .gender(NumberConstants.MALE).build().get();
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
                 .willReturn(false);
@@ -518,17 +513,15 @@ class CrewServiceImplTest {
     @Test
     void when_PermissionNotRequiredCrew_Then_ImmediateJoin() {
         // given
-        CrewDto crewDto = createCrewDto(List.of(
-                "minAge", 25,
-                "maxAge", 30,
-                "gender", CrewGender.FEMALE,
-                "permissionRequired", false,
-                "answerRequired", false
-        ));
-        UserDto userDto = createUserDto(List.of(
-                "birthday", LocalDate.now().minusYears(26),
-                "gender", NumberConstants.FEMALE
-        ));
+        CrewDto crewDto = createCrewDto()
+                .minAge(25)
+                .maxAge(30)
+                .gender(CrewGender.FEMALE)
+                .permissionRequired(false)
+                .answerRequired(false).build().get();
+        UserDto userDto = createUserDto()
+                .birthday(LocalDate.now().minusYears(26))
+                .gender(NumberConstants.FEMALE).build().get();
 
         String answer = "가입신청 답변";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
@@ -557,11 +550,11 @@ class CrewServiceImplTest {
     @Test
     void when_AnswerRequiredButNoAnswer_Then_AnswerRequiredException() {
         // given
-        CrewDto crewDto = createCrewDto(List.of(
-                "permissionRequired", true,
-                "answerRequired", true
-        ));
-        UserDto userDto = createUserDto();
+        CrewDto crewDto = createCrewDto()
+                .gender(CrewGender.ANY)
+                .permissionRequired(true)
+                .answerRequired(true).build().get();
+        UserDto userDto = createUserDto().build().get();
         String answer = "";
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userDto.id()))
                 .willReturn(false);
@@ -590,7 +583,7 @@ class CrewServiceImplTest {
     void should_WithdrawApplication() {
         // given
         Long userId = 1L;
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), userId))
                 .willReturn(true);
 
@@ -609,7 +602,7 @@ class CrewServiceImplTest {
     void when_NotExistingApplication_Then_NotFoundApplicationException1() {
         // given
         Long userId = 1L;
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), userId))
                 .willReturn(false);
 
@@ -627,7 +620,7 @@ class CrewServiceImplTest {
     @Test
     void should_ApproveApplication() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), applicantId))
                 .willReturn(true);
@@ -646,7 +639,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotCrewCreator_Then_ForbiddenException3() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         Long invalidUserId = 3L;
 
@@ -663,7 +656,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotExistingApplication_Then_NotFoundApplicationException2() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), applicantId))
                 .willReturn(false);
@@ -682,7 +675,7 @@ class CrewServiceImplTest {
     @Test
     void should_DisapproveApplication() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), applicantId))
                 .willReturn(true);
@@ -701,7 +694,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotCrewCreator_Then_ForbiddenException4() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         Long invalidUserId = 3L;
 
@@ -718,7 +711,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotExistingApplication_Then_NotFoundApplicationException3() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long applicantId = 2L;
         given(crewApplicationReader.existsByCrewIdAndUserId(crewDto.id(), applicantId))
                 .willReturn(false);
@@ -737,7 +730,7 @@ class CrewServiceImplTest {
     @Test
     void should_LeaveCrew() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = 11L;
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userId))
                 .willReturn(true);
@@ -760,7 +753,7 @@ class CrewServiceImplTest {
     @Test
     void when_CrewCreator_Then_CreatorDeleteForbiddenException() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = crewDto.userDto().id();
 
         // when & then
@@ -778,7 +771,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotExistingCrewMember_Then_NotFoundCrewMemberException() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = 11L;
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), userId))
                 .willReturn(false);
@@ -799,7 +792,7 @@ class CrewServiceImplTest {
     @Test
     void should_ExpelMember() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long memberId = 11L;
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), memberId))
                 .willReturn(true);
@@ -822,7 +815,7 @@ class CrewServiceImplTest {
     @Test
     void when_NotCrewCreator_Then_ForbiddenException5() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long memberId = 11L;
         Long invalidUserId = 12L;
 
@@ -841,7 +834,7 @@ class CrewServiceImplTest {
     @Test
     void when_CrewCreator_Then_CreatorExpelForbiddenException() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
         Long userId = crewDto.userDto().id();
 
         // when & then
@@ -859,7 +852,8 @@ class CrewServiceImplTest {
     @Test
     void when_NotExistingCrewMember_Then_NotFoundCrewMemberException2() {
         // given
-        CrewDto crewDto = createCrewDto();
+        CrewDto crewDto = createCrewDto().build().get();
+        CrewDto temp = DomainFixtureFactory.TestCrewDto.builder().build().get();
         Long memberId = 11L;
         given(crewMemberReader.existsByCrewIdAndUserId(crewDto.id(), memberId))
                 .willReturn(false);
@@ -876,38 +870,6 @@ class CrewServiceImplTest {
         then(crewMemberStore).shouldHaveNoInteractions();
     }
 
-    private User createUser() {
-        return User.of(
-                1525L,
-                "userEmail",
-                "userNickname",
-                "userPassword",
-                1,
-                1,
-                LocalDate.now(),
-                "userProfileImage",
-                LocalDateTime.of(1999, 3, 1, 7, 50),
-                LocalDateTime.of(1999, 3, 1, 7, 50),
-                UserStatus.ENABLE
-        );
-    }
-
-    private User createUser(Long userId) {
-        return User.of(
-                userId,
-                "userEmail",
-                "userNickname",
-                "userPassword",
-                1,
-                1,
-                LocalDate.now(),
-                "userProfileImage",
-                LocalDateTime.of(1999, 3, 1, 7, 50),
-                LocalDateTime.of(1999, 3, 1, 7, 50),
-                UserStatus.ENABLE
-        );
-    }
-
     private CrewMember createCrewMember(Long crewId, Long userId) {
         return CrewMember.of(
                 CrewMemberPK.of(userId, crewId),
@@ -916,41 +878,8 @@ class CrewServiceImplTest {
         );
     }
 
-    private Crew createCrew(Long crewId) {
-        return Crew.of(
-                crewId,
-                "크루 이름",
-                12,
-                30,
-                Region.강남구,
-                "크루 설명",
-                "크루 이미지",
-                CrewStatus.ACTIVATED,
-                createUser(),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                17,
-                45,
-                CrewGender.ANY,
-                true,
-                null,
-                false
-        );
-    }
-
-    private UserDto createUserDto(List<Object> objects) {
-        return DomainFixtureFactory.createUserDto(objects);
-    }
-
-    private UserDto createUserDto() {
-        return createUserDto(Collections.emptyList());
-    }
-
-    private CrewDto createCrewDto(List<Object> objects) {
-        return DomainFixtureFactory.createCrewDto(objects);
-    }
-
-    private CrewDto createCrewDto() {
-        return createCrewDto(Collections.emptyList());
+    private User createUser(Long userId) {
+        return DomainFixtureFactory.TestUser.createUser()
+                .id(userId).build().get();
     }
 }

--- a/orury-domain/build.gradle
+++ b/orury-domain/build.gradle
@@ -26,6 +26,12 @@ dependencies {
 
     testRuntimeOnly('com.mysql:mysql-connector-j')
 
+    //test fixtures
+    testFixturesAnnotationProcessor 'org.projectlombok:lombok'
+    testFixturesImplementation 'org.projectlombok:lombok'
+    testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
+    testFixturesImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 tasks.register("prepareKotlinBuildScriptModel") {}
 

--- a/orury-domain/build.gradle
+++ b/orury-domain/build.gradle
@@ -1,4 +1,8 @@
-////build.gradle 파일
+//build.gradle 파일
+plugins {
+    id 'java-test-fixtures'
+}
+
 dependencies {
     implementation project(':orury-common')
 

--- a/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
+++ b/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
@@ -1,0 +1,99 @@
+package org.orury.domain;
+
+import org.orury.domain.crew.domain.dto.CrewDto;
+import org.orury.domain.crew.domain.dto.CrewGender;
+import org.orury.domain.crew.domain.dto.CrewStatus;
+import org.orury.domain.global.domain.Region;
+import org.orury.domain.user.domain.dto.UserDto;
+import org.orury.domain.user.domain.dto.UserStatus;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+public class DomainFixtureFactory {
+
+    private DomainFixtureFactory() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static List<String> extractFields(List<Object> objects) {
+        return objects.stream()
+                .filter(o -> objects.indexOf(o) % 2 == 0)
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private static List<Object> extractValues(List<Object> objects) {
+        return objects.stream()
+                .filter(o -> objects.indexOf(o) % 2 == 1)
+                .toList();
+    }
+
+    private static void validateFields(List<String> fields, List<String> objectsFields) {
+        if (!fields.containsAll(objectsFields))
+            throw new IllegalArgumentException("Invalid field name in : " + objectsFields);
+    }
+
+    private static <T> T extractFieldValue(List<String> fields, List<Object> values, String fieldName, T defaultValue) {
+        int index = fields.indexOf(fieldName);
+        return index != -1 ? (T) values.get(index) : defaultValue;
+    }
+
+    private static final List<String> CREW_DTO_FIELD_NAMES = Arrays.stream(CrewDto.class.getDeclaredFields()).map(Field::getName).toList();
+
+    public static CrewDto createCrewDto(List<Object> objects) {
+        List<String> fields = extractFields(objects);
+        List<Object> values = extractValues(objects);
+
+        validateFields(CREW_DTO_FIELD_NAMES, fields);
+
+        return CrewDto.of(
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(0), 333L),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(1), "테스트크루"),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(2), 12),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(3), 30),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(4), Region.강남구),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(5), "크루 설명"),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(6), "orury/crew/crew_icon"),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(7), CrewStatus.ACTIVATED),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(8), createUserDto(Collections.emptyList())),
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(11), 15),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(12), 35),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(13), CrewGender.ANY),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(14), false),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(15), null),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(16), false),
+                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(17), List.of("크루태그1", "크루태그2"))
+        );
+    }
+
+    private static final List<String> USER_DTO_FIELD_NAMES = Arrays.stream(UserDto.class.getDeclaredFields()).map(Field::getName).toList();
+
+    public static UserDto createUserDto(List<Object> objects) {
+        List<String> fields = extractFields(objects);
+        List<Object> values = extractValues(objects);
+
+        validateFields(USER_DTO_FIELD_NAMES, fields);
+
+        return UserDto.of(
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(0), 111L),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(1), "userEmail"),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(2), "userNickname"),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(3), "userPassword"),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(4), 1),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(5), 1),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(6), LocalDate.now().minusYears(25)),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(7), "userProfileImage"),
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(10), UserStatus.ENABLE)
+        );
+    }
+}

--- a/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
+++ b/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
@@ -1,17 +1,21 @@
 package org.orury.domain;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.Builder;
+import lombok.Getter;
 import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.dto.CrewStatus;
+import org.orury.domain.crew.domain.entity.Crew;
+import org.orury.domain.global.constants.NumberConstants;
 import org.orury.domain.global.domain.Region;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.orury.domain.user.domain.dto.UserStatus;
+import org.orury.domain.user.domain.entity.User;
 
-import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 
@@ -21,79 +25,116 @@ public class DomainFixtureFactory {
         throw new IllegalStateException("Utility class");
     }
 
-    private static List<String> extractFields(List<Object> objects) {
-        return objects.stream()
-                .filter(o -> objects.indexOf(o) % 2 == 0)
-                .map(String::valueOf)
-                .toList();
+    private static final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Getter
+    @Builder
+    public static class TestUser {
+        private @Builder.Default Long id = 1L;
+        private @Builder.Default String email = "테스트이메일";
+        private @Builder.Default String nickname = "테스트닉네임";
+        private @Builder.Default String password = "테스트비밀번호";
+        private @Builder.Default int signUpType = 1;
+        private @Builder.Default int gender = NumberConstants.MALE;
+        private @Builder.Default LocalDate birthday = LocalDate.now().minusYears(25);
+        private @Builder.Default String profileImage = "프로필이미지";
+        private @Builder.Default UserStatus status = UserStatus.ENABLE;
+        private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
+        private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
+
+        public static TestUser.TestUserBuilder createUser() {
+            return TestUser.builder();
+        }
+
+        public User get() {
+            return mapper.convertValue(this, User.class);
+        }
     }
 
-    private static List<Object> extractValues(List<Object> objects) {
-        return objects.stream()
-                .filter(o -> objects.indexOf(o) % 2 == 1)
-                .toList();
+    @Getter
+    @Builder
+    public static class TestUserDto {
+        private @Builder.Default Long id = 2L;
+        private @Builder.Default String email = "testEamil";
+        private @Builder.Default String nickname = "testNickname";
+        private @Builder.Default String password = "testPassword";
+        private @Builder.Default int signUpType = 2;
+        private @Builder.Default int gender = NumberConstants.FEMALE;
+        private @Builder.Default LocalDate birthday = LocalDate.now().minusYears(24);
+        private @Builder.Default String profileImage = "testProfileImage";
+        private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
+        private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
+        private @Builder.Default UserStatus status = UserStatus.ENABLE;
+
+        public static TestUserDto.TestUserDtoBuilder createUserDto() {
+            return TestUserDto.builder();
+        }
+
+        public UserDto get() {
+            return mapper.convertValue(this, UserDto.class);
+        }
     }
 
-    private static void validateFields(List<String> fields, List<String> objectsFields) {
-        if (!fields.containsAll(objectsFields))
-            throw new IllegalArgumentException("Invalid field name in : " + objectsFields);
+    @Getter
+    @Builder
+    public static class TestCrew {
+        private @Builder.Default Long id = 3L;
+        private @Builder.Default String name = "테스트크루";
+        private @Builder.Default int memberCount = 12;
+        private @Builder.Default int capacity = 20;
+        private @Builder.Default Region region = Region.강남구;
+        private @Builder.Default String description = "크루 설명";
+        private @Builder.Default String icon = "orury/crew/crew_icon";
+        private @Builder.Default CrewStatus status = CrewStatus.ACTIVATED;
+        private @Builder.Default User user = TestUser.createUser().build().get();
+        private @Builder.Default int minAge = 15;
+        private @Builder.Default int maxAge = 30;
+        private @Builder.Default CrewGender gender = CrewGender.ANY;
+        private @Builder.Default boolean permissionRequired = false;
+        private @Builder.Default String question = null;
+        private @Builder.Default boolean answerRequired = false;
+        private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
+        private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
+
+        public static TestCrew.TestCrewBuilder createCrew() {
+            return TestCrew.builder();
+        }
+
+        public Crew get() {
+            return mapper.convertValue(this, Crew.class);
+        }
     }
 
-    private static <T> T extractFieldValue(List<String> fields, List<Object> values, String fieldName, T defaultValue) {
-        int index = fields.indexOf(fieldName);
-        return index != -1 ? (T) values.get(index) : defaultValue;
+    @Getter
+    @Builder
+    public static class TestCrewDto {
+        private @Builder.Default Long id = 4L;
+        private @Builder.Default String name = "testCrewDto";
+        private @Builder.Default int memberCount = 11;
+        private @Builder.Default int capacity = 21;
+        private @Builder.Default Region region = Region.중구;
+        private @Builder.Default String description = "testCrewDescription";
+        private @Builder.Default String icon = "testIcon";
+        private @Builder.Default CrewStatus status = CrewStatus.ACTIVATED;
+        private @Builder.Default UserDto userDto = TestUserDto.createUserDto().build().get();
+        private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
+        private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
+        private @Builder.Default int minAge = 14;
+        private @Builder.Default int maxAge = 31;
+        private @Builder.Default CrewGender gender = CrewGender.MALE;
+        private @Builder.Default boolean permissionRequired = true;
+        private @Builder.Default String question = "testQuestion";
+        private @Builder.Default boolean answerRequired = false;
+        private @Builder.Default List<String> tags = List.of("testTag1", "testTag2");
+
+        public static TestCrewDto.TestCrewDtoBuilder createCrewDto() {
+            return TestCrewDto.builder();
+        }
+
+        public CrewDto get() {
+            return mapper.convertValue(this, CrewDto.class);
+        }
     }
 
-    private static final List<String> CREW_DTO_FIELD_NAMES = Arrays.stream(CrewDto.class.getDeclaredFields()).map(Field::getName).toList();
 
-    public static CrewDto createCrewDto(List<Object> objects) {
-        List<String> fields = extractFields(objects);
-        List<Object> values = extractValues(objects);
-
-        validateFields(CREW_DTO_FIELD_NAMES, fields);
-
-        return CrewDto.of(
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(0), 333L),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(1), "테스트크루"),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(2), 12),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(3), 30),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(4), Region.강남구),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(5), "크루 설명"),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(6), "orury/crew/crew_icon"),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(7), CrewStatus.ACTIVATED),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(8), createUserDto(Collections.emptyList())),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(11), 15),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(12), 35),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(13), CrewGender.ANY),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(14), false),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(15), null),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(16), false),
-                extractFieldValue(fields, values, CREW_DTO_FIELD_NAMES.get(17), List.of("크루태그1", "크루태그2"))
-        );
-    }
-
-    private static final List<String> USER_DTO_FIELD_NAMES = Arrays.stream(UserDto.class.getDeclaredFields()).map(Field::getName).toList();
-
-    public static UserDto createUserDto(List<Object> objects) {
-        List<String> fields = extractFields(objects);
-        List<Object> values = extractValues(objects);
-
-        validateFields(USER_DTO_FIELD_NAMES, fields);
-
-        return UserDto.of(
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(0), 111L),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(1), "userEmail"),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(2), "userNickname"),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(3), "userPassword"),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(4), 1),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(5), 1),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(6), LocalDate.now().minusYears(25)),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(7), "userProfileImage"),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                extractFieldValue(fields, values, USER_DTO_FIELD_NAMES.get(10), UserStatus.ENABLE)
-        );
-    }
 }

--- a/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
+++ b/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
@@ -48,6 +48,10 @@ public class DomainFixtureFactory {
             return TestUser.builder();
         }
 
+        public static TestUser.TestUserBuilder createUser(Long userId) {
+            return TestUser.builder().id(userId);
+        }
+
         public User get() {
             return mapper.convertValue(this, User.class);
         }
@@ -162,6 +166,11 @@ public class DomainFixtureFactory {
 
         public static TestCrewMember.TestCrewMemberBuilder createCrewMember() {
             return TestCrewMember.builder();
+        }
+
+        public static TestCrewMember.TestCrewMemberBuilder createCrewMember(Long crewId, Long userId) {
+            return TestCrewMember.builder()
+                    .crewMemberPK(TestCrewMemberPK.createCrewMemberPK().crewId(crewId).userId(userId).build().get());
         }
 
         public CrewMember get() {

--- a/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
+++ b/orury-domain/src/testFixtures/java/org/orury/domain/DomainFixtureFactory.java
@@ -8,6 +8,8 @@ import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.dto.CrewStatus;
 import org.orury.domain.crew.domain.entity.Crew;
+import org.orury.domain.crew.domain.entity.CrewMember;
+import org.orury.domain.crew.domain.entity.CrewMemberPK;
 import org.orury.domain.global.constants.NumberConstants;
 import org.orury.domain.global.domain.Region;
 import org.orury.domain.user.domain.dto.UserDto;
@@ -133,6 +135,37 @@ public class DomainFixtureFactory {
 
         public CrewDto get() {
             return mapper.convertValue(this, CrewDto.class);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class TestCrewMemberPK {
+        private @Builder.Default Long crewId = 5L;
+        private @Builder.Default Long userId = 6L;
+
+        public static TestCrewMemberPK.TestCrewMemberPKBuilder createCrewMemberPK() {
+            return TestCrewMemberPK.builder();
+        }
+
+        public CrewMemberPK get() {
+            return mapper.convertValue(this, CrewMemberPK.class);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class TestCrewMember {
+        private @Builder.Default CrewMemberPK crewMemberPK = TestCrewMemberPK.createCrewMemberPK().build().get();
+        private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
+        private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
+
+        public static TestCrewMember.TestCrewMemberBuilder createCrewMember() {
+            return TestCrewMember.builder();
+        }
+
+        public CrewMember get() {
+            return mapper.convertValue(this, CrewMember.class);
         }
     }
 


### PR DESCRIPTION
## 개요
### 문제상황
  1. 기존에 테스트코드 전반에서 private으로 createUserDto()와 같이 테스트 Fixture(임의의 데이터)를 생성해주고 있었습니다.
  다만, 이 코드 중복이 너무 많이 발생하고 있어, 필드가 변경될 때 테스트코드 전반에서 수정이 이뤄져야 했습니다.
  2. 그리고 설정하고자 하는 필드가 달라지면 그에 따라 별도의 메서드를 생성해야 했습니다. 
  ex. createUser(Long userId), createUser(String nickname, String email)

### 변경사항
- 우선은 1번을 해결하기 위해, [Object Mother 패턴](https://velog.io/@yeongori/Spring-Boot-Mother-Object-pattern)과 [testFixtures 플러그인](https://toss.tech/article/how-to-manage-test-dependency-in-gradle)을 적용했습니다.
  - domain 모듈에 DomainFixtureFactory라는 클래스를 생성하고, UserDto와 CrewDto를 생성하는 메서드를 넣어줬습니다.
  - testImplementation(testFixture())를 통해 Client 모듈에서 domain 모듈의 테스트 전체가 아닌, testFixtures만 가져올 수 있도록 설정했습니다.
  - 아래는 Domain 모듈의 TestFixtures 패키지에 관한 의존성 설정 도식입니다. (빨간색 화살표가 testFixtures 의존성)
    ![image](https://github.com/Kernel360/f1-Orury-Backend/assets/147565215/5fcb45fb-80b9-4c2c-a483-34c6d3678515)

- 다음으로 2번을 해결해주고 싶었는데, 해당 이슈에 대해서는 검색해도 적절한 해답을 찾을 수 없어 자의적으로 구현해봤는데, 
이 방식에 대해서는 괜찮은 것인지 철저한 피드백이 필요합니다.
  - 최종 Builder 정적 클래스의 선택 과정은, [어제 작성한 포스트](https://velog.io/@green2/Flexible-Test-Fixture-Creation)를 읽으시면 확인하실 수 있습니다.


closed #390 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
