### PR TITLE
Feat : 크루 상세 조회 시 크루 가입 질문 추가 전달

### DIFF
--- a/orury-client/src/main/java/org/orury/client/auth/application/jwt/JwtTokenServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/auth/application/jwt/JwtTokenServiceImpl.java
@@ -31,7 +31,7 @@ public class JwtTokenServiceImpl implements JwtTokenService {
     private static final String JWT_TOKEN_PREFIX = "Bearer ";
     private static final String TOKEN_HEADER_NAME = "Authorization";
 
-    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24L; // 1일
     private static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7L; // 7일
 
     // 비회원 전용 토큰

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewResponse.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewResponse.java
@@ -18,6 +18,7 @@ public record CrewResponse(
         String icon,
         CrewStatus status,
         String headProfileImage,
+        String question,
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         LocalDateTime createdAt,
         @JsonFormat(shape = JsonFormat.Shape.STRING)
@@ -36,6 +37,7 @@ public record CrewResponse(
                 crewDto.icon(),
                 crewDto.status(),
                 crewDto.userDto().profileImage(),
+                crewDto.question(),
                 crewDto.createdAt(),
                 crewDto.updatedAt(),
                 crewDto.tags(),

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewResponse.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record CrewResponse(
         Long id,
         String name,
+        String headName,
         int memberCount,
         int capacity,
         Region region,
@@ -30,6 +31,7 @@ public record CrewResponse(
         return new CrewResponse(
                 crewDto.id(),
                 crewDto.name(),
+                crewDto.userDto().nickname(),
                 crewDto.memberCount(),
                 crewDto.capacity(),
                 crewDto.region(),


### PR DESCRIPTION
## 개요
크루 가입 화면으로 넘어갈 때 크루 가입 질문이 필요한데, 이를 추가로 전달하기 위한 API를 따로 파는것보단 그냥 상세조회에 전달해주기로 했습니다. (정아님이랑 협의 완료)

추가로, 현재 액세스토큰 유효시간이 1시간입니다. 프론트에서 리프레쉬 토큰 발급할 때 렌더링 관련 이슈가 있어서, 해당 이슈가 해결될때까지는 1일로 설정해뒀습니다.

closed #404 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
