### PR TITLE
Feat : (가입한/가입신청한) 내 크루 목록 조회 API 구현

### DIFF
--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
@@ -1,6 +1,7 @@
 package org.orury.client.crew.application;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.function.TriFunction;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.client.crew.interfaces.request.CrewRequest;
 import org.orury.client.crew.interfaces.response.CrewMembersResponse;
@@ -14,7 +15,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import static org.orury.domain.global.constants.NumberConstants.*;
 
@@ -42,10 +45,14 @@ public class CrewFacade {
         return convertCrewDtosToCrewsResponses(crewDtos);
     }
 
-    public Page<CrewsResponse> getMyCrews(Long userId, int page) {
-        var pageRequest = PageRequest.of(page, CREW_PAGINATION_SIZE);
-        Page<CrewDto> crewDtos = crewService.getCrewDtosByUserId(userId, pageRequest);
-        return convertCrewDtosToCrewsResponses(crewDtos);
+    public List<CrewsResponse> getJoinedCrews(Long userId) {
+        List<CrewDto> crewDtos = crewService.getJoinedCrewDtos(userId);
+        return convertCrewDtosToCrewsResponses(crewDtos, userId, crewService::getJoinedAt, CrewsResponse::ofWithJoinedTime);
+    }
+
+    public List<CrewsResponse> getAppliedCrews(Long userId) {
+        List<CrewDto> crewDtos = crewService.getAppliedCrewDtos(userId);
+        return convertCrewDtosToCrewsResponses(crewDtos, userId, crewService::getAppliedAt, CrewsResponse::ofWithAppliedTime);
     }
 
     public CrewResponse getCrewByCrewId(Long userId, Long crewId) {
@@ -115,5 +122,18 @@ public class CrewFacade {
         return userDtos.stream()
                 .map(userDto -> CrewMembersResponse.of(userDto, userId, crewDto.userDto().id()))
                 .toList();
+    }
+
+    private List<CrewsResponse> convertCrewDtosToCrewsResponses(
+            List<CrewDto> crewDtos,
+            Long userId, BiFunction<Long, Long, LocalDateTime> biFunction,
+            TriFunction<CrewDto, List<String>, LocalDateTime, CrewsResponse> triFunction
+    ) {
+        return crewDtos.stream()
+                .map(crewDto -> {
+                    List<String> userImages = crewService.getUserImagesByCrew(crewDto, MAXIMUM_OF_CREW_LIST_THUMBNAILS);
+                    LocalDateTime time = biFunction.apply(crewDto.id(), userId);
+                    return triFunction.apply(crewDto, userImages, time);
+                }).toList();
     }
 }

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CrewService {
@@ -18,7 +19,9 @@ public interface CrewService {
 
     Page<CrewDto> getCrewDtosByRecommend(Pageable pageable);
 
-    Page<CrewDto> getCrewDtosByUserId(Long userId, Pageable pageable);
+    List<CrewDto> getJoinedCrewDtos(Long userId);
+
+    List<CrewDto> getAppliedCrewDtos(Long userId);
 
     List<String> getUserImagesByCrew(CrewDto crewDto, int maximumCount);
 
@@ -41,6 +44,10 @@ public interface CrewService {
     void leaveCrew(CrewDto crewDto, Long userId);
 
     void expelMember(CrewDto crewDto, Long memberId, Long userId);
+
+    LocalDateTime getJoinedAt(Long crewId, Long userId);
+
+    LocalDateTime getAppliedAt(Long crewId, Long userId);
 
     List<UserDto> getUserDtosByCrew(Long crewId, Long userId);
 }

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -40,6 +41,7 @@ public class CrewServiceImpl implements CrewService {
     private final CrewTagStore crewTagStore;
     private final CrewMemberReader crewMemberReader;
     private final CrewMemberStore crewMemberStore;
+    private final CrewApplicationReader crewApplicationReader;
     private final CrewApplicationStore crewApplicationStore;
     private final MeetingStore meetingStore;
     private final MeetingMemberStore meetingMemberStore;
@@ -75,27 +77,28 @@ public class CrewServiceImpl implements CrewService {
     @Transactional(readOnly = true)
     public Page<CrewDto> getCrewDtosByRank(Pageable pageable) {
         Page<Crew> crews = crewReader.getCrewsByRank(pageable);
-        return crews.map(crew -> {
-            List<String> tags = crewTagReader.getTagsByCrewId(crew.getId());
-            return CrewDto.from(crew, tags);
-        });
+        return convertCrewsToCrewDtos(crews);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Page<CrewDto> getCrewDtosByRecommend(Pageable pageable) {
         Page<Crew> crews = crewReader.getCrewsByRecommend(pageable);
-        return crews.map(crew -> {
-            List<String> tags = crewTagReader.getTagsByCrewId(crew.getId());
-            return CrewDto.from(crew, tags);
-        });
+        return convertCrewsToCrewDtos(crews);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CrewDto> getCrewDtosByUserId(Long userId, Pageable pageable) {
-        return crewReader.getCrewsByUserId(userId, pageable)
-                .map(CrewDto::from);
+    public List<CrewDto> getJoinedCrewDtos(Long userId) {
+        List<Crew> crews = crewReader.getJoinedCrewsByUserId(userId);
+        return convertCrewsToCrewDtos(crews);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CrewDto> getAppliedCrewDtos(Long userId) {
+        List<Crew> crews = crewReader.getAppliedCrewsByUserId(userId);
+        return convertCrewsToCrewDtos(crews);
     }
 
     @Override
@@ -201,6 +204,18 @@ public class CrewServiceImpl implements CrewService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public LocalDateTime getJoinedAt(Long crewId, Long userId) {
+        return crewMemberReader.getCrewMemberByCrewIdAndUserId(crewId, userId).getCreatedAt();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LocalDateTime getAppliedAt(Long crewId, Long userId) {
+        return crewApplicationReader.getCrewApplicationByCrewIdAndUserId(crewId, userId).getCreatedAt();
+    }
+
+    @Override
     public List<UserDto> getUserDtosByCrew(Long crewId, Long userId) {
         crewPolicy.validateCrewMember(crewId, userId);
         return crewMemberReader.getMembersByCrewId(crewId)
@@ -214,5 +229,20 @@ public class CrewServiceImpl implements CrewService {
         meetingStore.deleteAllByUserIdAndCrewId(memberId, crewId);
 
         crewMemberStore.subtractCrewMember(crewId, memberId);
+    }
+
+    private Page<CrewDto> convertCrewsToCrewDtos(Page<Crew> crews) {
+        return crews.map(crew -> {
+            List<String> tags = crewTagReader.getTagsByCrewId(crew.getId());
+            return CrewDto.from(crew, tags);
+        });
+    }
+
+    private List<CrewDto> convertCrewsToCrewDtos(List<Crew> crews) {
+        return crews.stream()
+                .map(crew -> {
+                    List<String> tags = crewTagReader.getTagsByCrewId(crew.getId());
+                    return CrewDto.from(crew, tags);
+                }).toList();
     }
 }

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
@@ -54,7 +54,7 @@ public class CrewController {
         return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
     }
 
-    @Operation(summary = "내 크루 조회", description = "내가 가입한 크루를 조회한다.")
+    @Operation(summary = "가입 신청한 크루 조회", description = "내가 가입 신청한 크루를 조회한다.")
     @GetMapping("/mycrew")
     public ApiResponse getJoinedCrews(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         List<CrewsResponse> pageResponse = crewFacade.getJoinedCrews(userPrincipal.id());

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
@@ -56,8 +56,16 @@ public class CrewController {
 
     @Operation(summary = "내 크루 조회", description = "내가 가입한 크루를 조회한다.")
     @GetMapping("/mycrew")
-    public ApiResponse getMyCrews(@RequestParam int page, @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        Page<CrewsResponse> pageResponse = crewFacade.getMyCrews(userPrincipal.id(), page);
+    public ApiResponse getJoinedCrews(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<CrewsResponse> pageResponse = crewFacade.getJoinedCrews(userPrincipal.id());
+
+        return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
+    }
+
+    @Operation(summary = "내 크루 조회", description = "내가 가입한 크루를 조회한다.")
+    @GetMapping("/myApplications")
+    public ApiResponse getAppliedCrews(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<CrewsResponse> pageResponse = crewFacade.getAppliedCrews(userPrincipal.id());
 
         return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
     }

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewsResponse.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewsResponse.java
@@ -20,7 +20,9 @@ public record CrewsResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         LocalDateTime updatedAt,
         List<String> tags,
-        List<String> userImages
+        List<String> userImages,
+        LocalDateTime joinedTime,
+        LocalDateTime appliedTime
 ) implements IdIdentifiable {
     public static CrewsResponse of(CrewDto crewDto, List<String> userImages) {
         return new CrewsResponse(
@@ -33,7 +35,43 @@ public record CrewsResponse(
                 crewDto.createdAt(),
                 crewDto.updatedAt(),
                 crewDto.tags(),
-                userImages
+                userImages,
+                null,
+                null
+        );
+    }
+
+    public static CrewsResponse ofWithJoinedTime(CrewDto crewDto, List<String> userImages, LocalDateTime joinedTime) {
+        return new CrewsResponse(
+                crewDto.id(),
+                crewDto.name(),
+                crewDto.memberCount(),
+                crewDto.capacity(),
+                crewDto.region(),
+                crewDto.icon(),
+                crewDto.createdAt(),
+                crewDto.updatedAt(),
+                crewDto.tags(),
+                userImages,
+                joinedTime,
+                null
+        );
+    }
+
+    public static CrewsResponse ofWithAppliedTime(CrewDto crewDto, List<String> userImages, LocalDateTime appliedTime) {
+        return new CrewsResponse(
+                crewDto.id(),
+                crewDto.name(),
+                crewDto.memberCount(),
+                crewDto.capacity(),
+                crewDto.region(),
+                crewDto.icon(),
+                crewDto.createdAt(),
+                crewDto.updatedAt(),
+                crewDto.tags(),
+                userImages,
+                null,
+                appliedTime
         );
     }
 }

--- a/orury-client/src/test/java/org/orury/client/config/ServiceTest.java
+++ b/orury-client/src/test/java/org/orury/client/config/ServiceTest.java
@@ -168,7 +168,7 @@ public abstract class ServiceTest {
         authService = new AuthServiceImpl(userReader, userStore, jwtTokenService, oAuthServiceManager);
         commentService = new CommentServiceImpl(commentReader, commentStore);
         postService = new PostServiceImpl(postReader, postStore, imageStore);
-        crewService = new CrewServiceImpl(crewReader, crewStore, crewTagReader, crewTagStore, crewMemberReader, crewMemberStore, crewApplicationStore, meetingStore, meetingMemberStore, userReader, imageStore, crewPolicy, crewCreatePolicy, crewUpdatePolicy, crewApplicationPolicy);
+        crewService = new CrewServiceImpl(crewReader, crewStore, crewTagReader, crewTagStore, crewMemberReader, crewMemberStore, crewApplicationReader, crewApplicationStore, meetingStore, meetingMemberStore, userReader, imageStore, crewPolicy, crewCreatePolicy, crewUpdatePolicy, crewApplicationPolicy);
         oAuthService = new KakaoOAuthService(kakaoAuthClient, kakaoKapiClient);
         gymService = new GymServiceImpl(gymReader, gymStore);
         reviewService = new ReviewServiceImpl(reviewReader, reviewStore, gymStore, imageStore);

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -89,27 +90,54 @@ class CrewFacadeTest extends FacadeTest {
                 .getUserImagesByCrew(any(), anyInt());
     }
 
-    @DisplayName("페이지번호를 받으면, 유저id에 따른 크루 목록을 반환한다.")
+    @DisplayName("유저id를 받으면, 유저id에 따른 가입된 크루 목록을 반환한다.")
     @Test
-    void should_GetMyCrews() {
+    void should_GetJoinedCrews() {
         // given
         Long userId = 23L;
-        int page = 2;
         List<CrewDto> crewDtos = List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get());
-        Page<CrewDto> crewDtoPage = new PageImpl<>(crewDtos, PageRequest.of(page, 10), 2);
-        given(crewService.getCrewDtosByUserId(anyLong(), any()))
-                .willReturn(crewDtoPage);
+        given(crewService.getJoinedCrewDtos(anyLong()))
+                .willReturn(crewDtos);
         given(crewService.getUserImagesByCrew(any(CrewDto.class), anyInt()))
                 .willReturn(mock(List.class));
+        given((crewService.getJoinedAt(anyLong(), anyLong())))
+                .willReturn(LocalDateTime.now().minusYears(1));
 
         // when
-        crewFacade.getMyCrews(userId, page);
+        crewFacade.getJoinedCrews(userId);
 
         // then
         then(crewService).should(times(1))
-                .getCrewDtosByUserId(anyLong(), any());
+                .getJoinedCrewDtos(anyLong());
         then(crewService).should(times(crewDtos.size()))
                 .getUserImagesByCrew(any(), anyInt());
+        then(crewService).should(times(crewDtos.size()))
+                .getJoinedAt(anyLong(), anyLong());
+    }
+
+    @DisplayName("유저id를 받으면, 유저id에 따른 가입신청한 크루 목록을 반환한다.")
+    @Test
+    void should_getAppliedCrews() {
+        // given
+        Long userId = 262L;
+        List<CrewDto> crewDtos = List.of(createCrewDto(694L).build().get(), createCrewDto(256L).build().get());
+        given(crewService.getAppliedCrewDtos(anyLong()))
+                .willReturn(crewDtos);
+        given(crewService.getUserImagesByCrew(any(CrewDto.class), anyInt()))
+                .willReturn(mock(List.class));
+        given((crewService.getAppliedAt(anyLong(), anyLong())))
+                .willReturn(LocalDateTime.now().minusYears(1));
+
+        // when
+        crewFacade.getAppliedCrews(userId);
+
+        // then
+        then(crewService).should(times(1))
+                .getAppliedCrewDtos(anyLong());
+        then(crewService).should(times(crewDtos.size()))
+                .getUserImagesByCrew(any(), anyInt());
+        then(crewService).should(times(crewDtos.size()))
+                .getAppliedAt(anyLong(), anyLong());
     }
 
     @DisplayName("유저id, 크루id를 받으면, 크루정보를 반환한다.")
@@ -333,8 +361,9 @@ class CrewFacadeTest extends FacadeTest {
         CrewDto crewDto = createCrewDto(crewId).build().get();
         given(crewService.getCrewDtoById(anyLong()))
                 .willReturn(crewDto);
+        List<UserDto> userDtos = List.of(createUserDto(1111L).build().get(), createUserDto(2222L).build().get());
         given(crewService.getUserDtosByCrew(anyLong(), anyLong()))
-                .willReturn(mock(List.class));
+                .willReturn(userDtos);
 
         // when
         crewFacade.getCrewMembers(crewId, userId);

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewApplicationReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewApplicationReader.java
@@ -10,4 +10,6 @@ public interface CrewApplicationReader {
     List<CrewApplication> findAllByCrewId(Long crewId);
 
     int countByUserId(Long userId);
+
+    CrewApplication getCrewApplicationByCrewIdAndUserId(Long crewId, Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewMemberReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewMemberReader.java
@@ -13,4 +13,6 @@ public interface CrewMemberReader {
     List<User> getMembersByCrewId(Long crewId);
 
     List<CrewMember> getOtherCrewMembersByCrewIdMaximum(Long crewId, Long crewCreatorId, int maximum);
+
+    CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewReader.java
@@ -4,6 +4,7 @@ import org.orury.domain.crew.domain.entity.Crew;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CrewReader {
@@ -13,5 +14,7 @@ public interface CrewReader {
 
     Page<Crew> getCrewsByRecommend(Pageable pageable);
 
-    Page<Crew> getCrewsByUserId(Long userId, Pageable pageable);
+    List<Crew> getJoinedCrewsByUserId(Long userId);
+
+    List<Crew> getAppliedCrewsByUserId(Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationReaderImpl.java
@@ -26,4 +26,9 @@ public class CrewApplicationReaderImpl implements CrewApplicationReader {
     public int countByUserId(Long userId) {
         return crewApplicationRepository.countByCrewApplicationPK_UserId(userId);
     }
+
+    @Override
+    public CrewApplication getCrewApplicationByCrewIdAndUserId(Long crewId, Long userId) {
+        return crewApplicationRepository.getCrewApplicationByCrewApplicationPK_CrewIdAndCrewApplicationPK_UserId(crewId, userId);
+    }
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationRepository.java
@@ -11,5 +11,9 @@ public interface CrewApplicationRepository extends JpaRepository<CrewApplication
 
     List<CrewApplication> findByCrewApplicationPK_CrewId(Long crewId);
 
+    List<CrewApplication> findByCrewApplicationPK_UserId(Long userId);
+
     int countByCrewApplicationPK_UserId(Long userId);
+
+    CrewApplication getCrewApplicationByCrewApplicationPK_CrewIdAndCrewApplicationPK_UserId(Long crewId, Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberReaderImpl.java
@@ -39,4 +39,9 @@ public class CrewMemberReaderImpl implements CrewMemberReader {
     public List<CrewMember> getOtherCrewMembersByCrewIdMaximum(Long crewId, Long crewCreatorId, int maximum) {
         return crewMemberRepository.findByCrewMemberPK_CrewIdAndCrewMemberPK_UserIdNot(crewId, crewCreatorId, PageRequest.of(0, maximum));
     }
+
+    @Override
+    public CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId) {
+        return crewMemberRepository.getCrewMemberByCrewMemberPK_CrewIdAndCrewMemberPK_UserId(crewId, userId);
+    }
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberRepository.java
@@ -17,4 +17,6 @@ public interface CrewMemberRepository extends JpaRepository<CrewMember, CrewMemb
     int countByCrewMemberPK_UserId(Long userId);
 
     List<CrewMember> findByCrewMemberPK_CrewIdAndCrewMemberPK_UserIdNot(Long crewId, Long crewCreatorId, PageRequest pageRequest);
+
+    CrewMember getCrewMemberByCrewMemberPK_CrewIdAndCrewMemberPK_UserId(Long crewId, Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewReaderImpl.java
@@ -3,8 +3,6 @@ package org.orury.domain.crew.infrastructures;
 import lombok.RequiredArgsConstructor;
 import org.orury.domain.crew.domain.CrewReader;
 import org.orury.domain.crew.domain.entity.Crew;
-import org.orury.domain.crew.domain.entity.CrewMember;
-import org.orury.domain.crew.domain.entity.CrewMemberPK;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -17,6 +15,7 @@ import java.util.Optional;
 public class CrewReaderImpl implements CrewReader {
     private final CrewRepository crewRepository;
     private final CrewMemberRepository crewMemberRepository;
+    private final CrewApplicationRepository crewApplicationRepository;
 
     @Override
     public Optional<Crew> findById(Long crewId) {
@@ -34,14 +33,18 @@ public class CrewReaderImpl implements CrewReader {
     }
 
     @Override
-    public Page<Crew> getCrewsByUserId(Long userId, Pageable pageable) {
-        List<CrewMember> crewMembers = crewMemberRepository.findByCrewMemberPK_UserId(userId);
-
-        List<Long> crewIds = crewMembers.stream()
-                .map(CrewMember::getCrewMemberPK)
-                .map(CrewMemberPK::getCrewId)
+    public List<Crew> getJoinedCrewsByUserId(Long userId) {
+        return crewMemberRepository.findByCrewMemberPK_UserId(userId).stream()
+                .map(crewMember -> crewMember.getCrewMemberPK().getCrewId())
+                .map(crewRepository::getCrewById)
                 .toList();
+    }
 
-        return crewRepository.findAllByIdIn(crewIds, pageable);
+    @Override
+    public List<Crew> getAppliedCrewsByUserId(Long userId) {
+        return crewApplicationRepository.findByCrewApplicationPK_UserId(userId).stream()
+                .map(crewApplication -> crewApplication.getCrewApplicationPK().getCrewId())
+                .map(crewRepository::getCrewById)
+                .toList();
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewRepository.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 public interface CrewRepository extends JpaRepository<Crew, Long> {
 
+    Crew getCrewById(Long crewId);
+
     Page<Crew> findByOrderByMemberCountDesc(Pageable pageable);
 
     Page<Crew> findByOrderByCreatedAtDesc(Pageable pageable);

--- a/orury-domain/src/test/java/org/orury/domain/config/InfrastructureTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/config/InfrastructureTest.java
@@ -181,7 +181,7 @@ public abstract class InfrastructureTest {
         crewApplicationStore = new CrewApplicationStoreImpl(crewApplicationRepository, crewRepository, crewMemberRepository);
         crewMemberReader = new CrewMemberReaderImpl(crewMemberRepository, userRepository);
         crewMemberStore = new CrewMemberStoreImpl(crewMemberRepository, crewRepository);
-        crewReader = new CrewReaderImpl(crewRepository, crewMemberRepository);
+        crewReader = new CrewReaderImpl(crewRepository, crewMemberRepository, crewApplicationRepository);
         crewStore = new CrewStoreImpl(crewRepository);
         crewTagReader = new CrewTagReaderImpl(crewTagRepository);
         crewTagStore = new CrewTagStoreImpl(crewTagRepository);

--- a/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewApplicationReaderImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewApplicationReaderImplTest.java
@@ -48,4 +48,15 @@ class CrewApplicationReaderImplTest extends InfrastructureTest {
         then(crewApplicationRepository).should(only())
                 .countByCrewApplicationPK_UserId(anyLong());
     }
+
+    @DisplayName("크루id와 유저id를 받아, 크루지원을 조회한다.")
+    @Test
+    void getCrewApplicationByCrewIdAndUserId() {
+        // given & when
+        crewApplicationReader.getCrewApplicationByCrewIdAndUserId(anyLong(), anyLong());
+
+        // then
+        then(crewApplicationRepository).should(only())
+                .getCrewApplicationByCrewApplicationPK_CrewIdAndCrewApplicationPK_UserId(anyLong(), anyLong());
+    }
 }

--- a/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewMemberReaderImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewMemberReaderImplTest.java
@@ -79,4 +79,15 @@ class CrewMemberReaderImplTest extends InfrastructureTest {
         then(crewMemberRepository).should(only())
                 .findByCrewMemberPK_CrewIdAndCrewMemberPK_UserIdNot(anyLong(), anyLong(), any(PageRequest.class));
     }
+
+    @DisplayName("크루id와 유저id를 받아, 해당 크루멤버를 반환한다.")
+    @Test
+    void getCrewMemberByCrewIdAndUserId() {
+        // given & when
+        crewMemberReader.getCrewMemberByCrewIdAndUserId(anyLong(), anyLong());
+
+        // then
+        then(crewMemberRepository).should(only())
+                .getCrewMemberByCrewMemberPK_CrewIdAndCrewMemberPK_UserId(anyLong(), anyLong());
+    }
 }

--- a/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewReaderImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewReaderImplTest.java
@@ -5,17 +5,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.domain.config.InfrastructureTest;
+import org.orury.domain.crew.domain.entity.CrewApplication;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.*;
+import static org.orury.domain.CrewDomainFixture.TestCrewApplication.createCrewApplication;
 import static org.orury.domain.CrewDomainFixture.TestCrewMember.createCrewMember;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,7 +58,7 @@ class CrewReaderImplTest extends InfrastructureTest {
                 .findByOrderByCreatedAtDesc(any(Pageable.class));
     }
 
-    @DisplayName("userId와 Pageable을 받아, userId에 해당하는 크루 목록을 조회한다")
+    @DisplayName("userId를 받아, 해당 유저가 가입한 크루 목록을 반환한다")
     @Test
     void getCrewsByUserId() {
         // given & when
@@ -68,12 +70,34 @@ class CrewReaderImplTest extends InfrastructureTest {
         given(crewMemberRepository.findByCrewMemberPK_UserId(anyLong()))
                 .willReturn(crewMembers);
 
-        crewReader.getCrewsByUserId(4127L, mock(Pageable.class));
+        crewReader.getJoinedCrewsByUserId(4127L);
 
         // then
         then(crewMemberRepository).should(only())
                 .findByCrewMemberPK_UserId(anyLong());
-        then(crewRepository).should(only())
-                .findAllByIdIn(anyList(), any(Pageable.class));
+        then(crewRepository).should(times(crewMembers.size()))
+                .getCrewById(anyLong());
+    }
+
+    @DisplayName("userId를 받아, 해당 유저가 가입신청한 크루 목록을 반환한다")
+    @Test
+    void getAppliedCrewsByUserId() {
+        // given
+        List<CrewApplication> crewApplications = List.of(
+                createCrewApplication().build().get(),
+                createCrewApplication().build().get(),
+                createCrewApplication().build().get()
+        );
+        given(crewApplicationRepository.findByCrewApplicationPK_UserId(anyLong()))
+                .willReturn(crewApplications);
+
+        // when
+        crewReader.getAppliedCrewsByUserId(4127L);
+
+        // then
+        then(crewApplicationRepository).should(only())
+                .findByCrewApplicationPK_UserId(anyLong());
+        then(crewRepository).should(times(crewApplications.size()))
+                .getCrewById(anyLong());
     }
 }


### PR DESCRIPTION
## 개요
내 가입/신청 크루 목록 조회 API를 구현할 때,
JoinedTime이나 AppliedTime을 어떤 레이어에서 결합하느냐에 따라 아래의 2가지 옵션이 있을 듯합니다.

1. Facade에서 결합
    - CrewsResponse를 구성할 때 인자로 JoinedTime/AppliedTime을 담기에, CrewDto에는 영향 없음.
    - 그러나 CrewFacade에서 CrewService 메서드를 여러번 호출해야 한다는 단점.
    (CrewDtos가져오고, 각 crewDto에 따른 가입/신청time조회)

2. Service에서 결합
    - CrewDto 구성할 때, JoinedTime/AppliedTime을 담아야 하므로, CrewDto에 2개의 새 필드가 추가됨.
    (Aggregate 개념에 의해 비합리적이지는 않아보임.)
    - CrewDto에 다른 기능에서는 활용하지 않는 필드 늘어난다는 단점.
    (DDD강의의 Info 개념이 적용될 여지 있어보임)

위 선택지에서 1번을 선택하여 구현했습니다. 그래서 CrewService에 많은 메서드가 생겨, 이를 원치 않는다면 CrewDto에 변경을 감수해서 2번을 채택하는 것이 좋을 듯 합니다. 혹시나 다른 방식이 있다면 언제든 환영입니다!!

추가로, CrewFacade에 코드 중복을 줄이기 위해, 인자와 반환 타입을 지정한 인터페이스(BiFunction과 TriFunction)를 활용해서
convertCrewDtosToCrewsResponses()를 구현했는데 이 방식이 더 가독성이 떨어진다면 해당 메서드 삭제하겠습니다!

closed #420

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
