### PR TITLE
Feat : 회원가입 시 유저 지역정보 받아오기

### DIFF
--- a/orury-client/src/main/java/org/orury/client/auth/interfaces/AuthController.java
+++ b/orury-client/src/main/java/org/orury/client/auth/interfaces/AuthController.java
@@ -2,6 +2,7 @@ package org.orury.client.auth.interfaces;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.client.auth.application.AuthFacade;
@@ -25,7 +26,7 @@ public class AuthController {
 
     @Operation(summary = "회원가입", description = "소셜 로그인을 통해 전달받은 정보를 기반으로 회원가입 수행")
     @PostMapping("/sign-up")
-    public ApiResponse signUp(@RequestBody SignUpRequest request) {
+    public ApiResponse signUp(@Valid @RequestBody SignUpRequest request) {
         var signUpResponse = authFacade.signUp(request.toDto());
         return ApiResponse.of(SIGNUP_SUCCESS.getMessage(), signUpResponse);
     }

--- a/orury-client/src/main/java/org/orury/client/auth/interfaces/request/SignUpRequest.java
+++ b/orury-client/src/main/java/org/orury/client/auth/interfaces/request/SignUpRequest.java
@@ -1,10 +1,14 @@
 package org.orury.client.auth.interfaces.request;
 
+import jakarta.validation.constraints.Size;
+import org.orury.domain.global.domain.Region;
+import org.orury.domain.global.validation.EnumValues;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.orury.domain.user.domain.dto.UserStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record SignUpRequest(
         int signUpType,
@@ -12,13 +16,17 @@ public record SignUpRequest(
         String nickname,
         int gender,
         LocalDate birthday,
-        String profileImage
+        String profileImage,
+
+        @Size(min = 1, max = 3, message = "활동 지역은 최소 1개, 최대 3개까지만 추가할 수 있습니다.")
+        @EnumValues(enumClass = Region.class, message = "유효하지 않은 지역이 포함되어 있습니다.")
+        List<Region> regions
 ) {
     // UUID 비밀번호를 암호화 시키기 위한 PasswordEncoder
     private static final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
-    public static SignUpRequest of(int signUpType, String email, String nickname, int gender, LocalDate birthday, String profileImage) {
-        return new SignUpRequest(signUpType, email, nickname, gender, birthday, profileImage);
+    public static SignUpRequest of(int signUpType, String email, String nickname, int gender, LocalDate birthday, String profileImage, List<Region> regions) {
+        return new SignUpRequest(signUpType, email, nickname, gender, birthday, profileImage, regions);
     }
 
     public UserDto toDto() {
@@ -33,7 +41,8 @@ public record SignUpRequest(
                 profileImage,
                 null,
                 null,
-                UserStatus.ENABLE
+                UserStatus.ENABLE,
+                regions
         );
     }
 }

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/request/UserInfoRequest.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/request/UserInfoRequest.java
@@ -18,7 +18,8 @@ public record UserInfoRequest(
                 ImageUrlConverter.splitUrlToImage(userDto.profileImage()),
                 userDto.createdAt(),
                 null,
-                userDto.status()
+                userDto.status(),
+                userDto.regions()
         );
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/auth/domain/dto/LoginDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/auth/domain/dto/LoginDto.java
@@ -37,7 +37,8 @@ public record LoginDto(
                         null,
                         null,
                         null,
-                        UserStatus.ENABLE
+                        UserStatus.ENABLE,
+                        null
                 ),
                 jwtToken,
                 flag

--- a/orury-domain/src/main/java/org/orury/domain/user/domain/dto/UserDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/user/domain/dto/UserDto.java
@@ -1,9 +1,11 @@
 package org.orury.domain.user.domain.dto;
 
+import org.orury.domain.global.domain.Region;
 import org.orury.domain.user.domain.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * DTO for {@link User}
@@ -19,7 +21,8 @@ public record UserDto(
         String profileImage,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        UserStatus status
+        UserStatus status,
+        List<Region> regions
 ) {
     public static UserDto of(
             Long id,
@@ -32,7 +35,8 @@ public record UserDto(
             String profileImage,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
-            UserStatus status
+            UserStatus status,
+            List<Region> regions
     ) {
         return new UserDto(
                 id,
@@ -45,7 +49,8 @@ public record UserDto(
                 profileImage,
                 createdAt,
                 updatedAt,
-                status
+                status,
+                regions
         );
     }
 
@@ -61,7 +66,8 @@ public record UserDto(
                 entity.getProfileImage(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
-                entity.getStatus()
+                entity.getStatus(),
+                entity.getRegions()
         );
     }
 
@@ -77,7 +83,8 @@ public record UserDto(
                 profileImage,
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
-                entity.getStatus()
+                entity.getStatus(),
+                entity.getRegions()
         );
     }
 
@@ -93,7 +100,8 @@ public record UserDto(
                 profileImage,
                 createdAt,
                 updatedAt,
-                status
+                status,
+                regions
         );
     }
 
@@ -109,7 +117,8 @@ public record UserDto(
                 newProfileImage,
                 createdAt,
                 updatedAt,
-                status
+                status,
+                regions
         );
     }
 
@@ -125,7 +134,8 @@ public record UserDto(
                 profileImage,
                 createdAt,
                 updatedAt,
-                status
+                status,
+                regions
         );
     }
 

--- a/orury-domain/src/main/java/org/orury/domain/user/domain/entity/User.java
+++ b/orury-domain/src/main/java/org/orury/domain/user/domain/entity/User.java
@@ -4,12 +4,15 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.orury.domain.base.db.AuditingField;
+import org.orury.domain.global.domain.Region;
+import org.orury.domain.global.domain.RegionConverter;
 import org.orury.domain.global.listener.UserProfileConverter;
 import org.orury.domain.user.domain.dto.UserStatus;
 import org.orury.domain.user.domain.dto.UserStatusConverter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @ToString
@@ -51,7 +54,11 @@ public class User extends AuditingField {
     @Convert(converter = UserStatusConverter.class)
     private UserStatus status;
 
-    private User(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt, UserStatus status) {
+    @Convert(converter = RegionConverter.class)
+    @Column(name = "regions", nullable = false)
+    private List<Region> regions;
+
+    private User(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt, UserStatus status, List<Region> regions) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
@@ -63,9 +70,10 @@ public class User extends AuditingField {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.status = status;
+        this.regions = regions;
     }
 
-    public static User of(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt, UserStatus status) {
-        return new User(id, email, nickname, password, signUpType, gender, birthday, profileImage, createdAt, updatedAt, status);
+    public static User of(Long id, String email, String nickname, String password, int signUpType, int gender, LocalDate birthday, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt, UserStatus status, List<Region> regions) {
+        return new User(id, email, nickname, password, signUpType, gender, birthday, profileImage, createdAt, updatedAt, status, regions);
     }
 }

--- a/orury-domain/src/main/resources/db/migration/V1.0.34__add_user_regions_column.sql
+++ b/orury-domain/src/main/resources/db/migration/V1.0.34__add_user_regions_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user`
+    ADD COLUMN regions VARCHAR(30) NOT NULL;

--- a/orury-domain/src/test/java/org/orury/domain/comment/infrastructure/CommentStoreImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/comment/infrastructure/CommentStoreImplTest.java
@@ -6,6 +6,7 @@ import org.orury.domain.comment.domain.entity.Comment;
 import org.orury.domain.comment.domain.entity.CommentLike;
 import org.orury.domain.config.InfrastructureTest;
 import org.orury.domain.global.constants.NumberConstants;
+import org.orury.domain.global.domain.Region;
 import org.orury.domain.post.domain.entity.Post;
 import org.orury.domain.user.domain.dto.UserStatus;
 import org.orury.domain.user.domain.entity.User;
@@ -143,7 +144,8 @@ class CommentStoreImplTest extends InfrastructureTest {
                 "userProfileImage",
                 LocalDateTime.of(1999, 3, 1, 7, 50),
                 LocalDateTime.of(1999, 3, 1, 7, 50),
-                UserStatus.ENABLE
+                UserStatus.ENABLE,
+                List.of(Region.강남구, Region.강북구)
         );
     }
 


### PR DESCRIPTION
## 개요
회원가입 시 유저의 지역정보를 User.regions에 받아오도록 처리했습니다.

### 상세 내용
이전에 작업한 Region을 복붙했습니다.
아래는 회원가입 시 사용된 테스트 데이터입니다.

```
{
  "signUpType" : 1,
  "email": "fhrek@naver.com",
  "nickname": "string",
  "gender": 1,
  "birthday": "2024-01-05",
  "profileImage": "default-user-image",
  "regions": [
      "강북구", "영등포구"
    ]
}
```

closed #430 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
