### PR TITLE
Feat : 크루 목록 정렬(추천순/인기순/활동순/최신순) 구현

### DIFF
--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
@@ -35,15 +35,28 @@ public class CrewFacade {
         crewService.createCrew(crewDto, image);
     }
 
-    public Page<CrewsResponse> getCrewsByRank(int page) {
+    public Page<CrewsResponse> getCrewsByRecommendedSort(int page, Long userId) {
         var pageRequest = PageRequest.of(page, CREW_PAGINATION_SIZE);
-        Page<CrewDto> crewDtos = crewService.getCrewDtosByRank(pageRequest);
+        var userDto = userService.getUserDtoById(userId);
+        Page<CrewDto> crewDtos = crewService.getCrewDtosByRecommendedSort(pageRequest, userDto);
         return convertCrewDtosToCrewsResponses(crewDtos);
     }
 
-    public Page<CrewsResponse> getCrewsByRecommend(int page) {
+    public Page<CrewsResponse> getCrewsByPopularSort(int page) {
         var pageRequest = PageRequest.of(page, CREW_PAGINATION_SIZE);
-        Page<CrewDto> crewDtos = crewService.getCrewDtosByRecommend(pageRequest);
+        Page<CrewDto> crewDtos = crewService.getCrewDtosByPopularSort(pageRequest);
+        return convertCrewDtosToCrewsResponses(crewDtos);
+    }
+
+    public Page<CrewsResponse> getCrewsByActiveSort(int page) {
+        var pageRequest = PageRequest.of(page, CREW_PAGINATION_SIZE);
+        Page<CrewDto> crewDtos = crewService.getCrewDtosByActiveSort(pageRequest);
+        return convertCrewDtosToCrewsResponses(crewDtos);
+    }
+
+    public Page<CrewsResponse> getCrewsByLatestSort(int page) {
+        var pageRequest = PageRequest.of(page, CREW_PAGINATION_SIZE);
+        Page<CrewDto> crewDtos = crewService.getCrewDtosByLatestSort(pageRequest);
         return convertCrewDtosToCrewsResponses(crewDtos);
     }
 

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -16,9 +16,13 @@ public interface CrewService {
 
     void createCrew(CrewDto crewDto, MultipartFile image);
 
-    Page<CrewDto> getCrewDtosByRank(Pageable pageable);
+    Page<CrewDto> getCrewDtosByRecommendedSort(Pageable pageable, UserDto userDto);
 
-    Page<CrewDto> getCrewDtosByRecommend(Pageable pageable);
+    Page<CrewDto> getCrewDtosByPopularSort(Pageable pageable);
+
+    Page<CrewDto> getCrewDtosByActiveSort(Pageable pageable);
+
+    Page<CrewDto> getCrewDtosByLatestSort(Pageable pageable);
 
     List<CrewDto> getJoinedCrewDtos(Long userId);
 

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -8,9 +8,11 @@ import org.orury.client.crew.application.policy.CrewUpdatePolicy;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.common.error.code.CrewErrorCode;
 import org.orury.common.error.exception.BusinessException;
+import org.orury.common.util.AgeUtils;
 import org.orury.domain.crew.domain.*;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
+import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.orury.domain.image.domain.ImageStore;
@@ -76,15 +78,31 @@ public class CrewServiceImpl implements CrewService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CrewDto> getCrewDtosByRank(Pageable pageable) {
-        Page<Crew> crews = crewReader.getCrewsByRank(pageable);
+    public Page<CrewDto> getCrewDtosByRecommendedSort(Pageable pageable, UserDto userDto) {
+        CrewGender userGender = CrewGender.convertFromUserGender(userDto.gender());
+        int userAge = AgeUtils.calculateAge(userDto.birthday());
+        Page<Crew> crews = crewReader.getCrewsByRecommendedSort(pageable, userGender, userAge);
         return convertCrewsToCrewDtos(crews);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CrewDto> getCrewDtosByRecommend(Pageable pageable) {
-        Page<Crew> crews = crewReader.getCrewsByRecommend(pageable);
+    public Page<CrewDto> getCrewDtosByPopularSort(Pageable pageable) {
+        Page<Crew> crews = crewReader.getCrewsByPopularSort(pageable);
+        return convertCrewsToCrewDtos(crews);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CrewDto> getCrewDtosByActiveSort(Pageable pageable) {
+        Page<Crew> crews = crewReader.getCrewsByActiveSort(pageable);
+        return convertCrewsToCrewDtos(crews);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CrewDto> getCrewDtosByLatestSort(Pageable pageable) {
+        Page<Crew> crews = crewReader.getCrewsByLatestSort(pageable);
         return convertCrewsToCrewDtos(crews);
     }
 

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
@@ -39,18 +39,34 @@ public class CrewController {
         return ApiResponse.of(CrewMessage.CREW_CREATED.getMessage());
     }
 
-    @Operation(summary = "크루 랭킹순 조회", description = "크루를 랭킹 순으로 조회한다.")
-    @GetMapping("/rank")
-    public ApiResponse getCrewsByRank(@RequestParam int page) {
-        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByRank(page);
+    @Operation(summary = "크루 추천순 조회", description = "크루를 추천 순으로 조회한다.")
+    @GetMapping("/recommended")
+    public ApiResponse getCrewsByRecommendedSort(@RequestParam int page, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByRecommendedSort(page, userPrincipal.id());
 
         return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
     }
 
-    @Operation(summary = "크루 추천순 조회", description = "크루를 추천 순으로 조회한다.")
-    @GetMapping("/recommend")
-    public ApiResponse getCrewsByRecommendation(@RequestParam int page) {
-        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByRecommend(page);
+    @Operation(summary = "크루 인기순 조회", description = "크루를 인기 순으로 조회한다.")
+    @GetMapping("/popular")
+    public ApiResponse getCrewsByPopularSort(@RequestParam int page) {
+        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByPopularSort(page);
+
+        return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
+    }
+
+    @Operation(summary = "크루 활동순 조회", description = "크루를 활동 순으로 조회한다.")
+    @GetMapping("/active")
+    public ApiResponse getCrewsByActiveSort(@RequestParam int page) {
+        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByActiveSort(page);
+
+        return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
+    }
+
+    @Operation(summary = "크루 최신순 조회", description = "크루를 최신 순으로 조회한다.")
+    @GetMapping("/latest")
+    public ApiResponse getCrewsByLatestSort(@RequestParam int page) {
+        Page<CrewsResponse> pageResponse = crewFacade.getCrewsByLatestSort(page);
 
         return ApiResponse.of(CrewMessage.CREWS_READ.getMessage(), pageResponse);
     }

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
@@ -46,47 +46,84 @@ class CrewFacadeTest extends FacadeTest {
                 .createCrew(any(CrewDto.class), any(MultipartFile.class));
     }
 
-    @DisplayName("페이지번호를 받으면, 크루랭크에 따른 크루 목록을 반환한다.")
+    @DisplayName("페이지, 유저id를 받으면, 추천순으로 크루목록을 반환한다.")
     @Test
-    void should_GetCrewsByRank() {
+    void should_GetCrewsByRecommendedSort() {
         // given
-        int page = 2;
-        List<CrewDto> crewDtos = List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get());
-        Page<CrewDto> crewDtoPage = new PageImpl<>(crewDtos, PageRequest.of(page, 10), 2);
-        given(crewService.getCrewDtosByRank(any()))
-                .willReturn(crewDtoPage);
-        given(crewService.getUserImagesByCrew(any(CrewDto.class), anyInt()))
-                .willReturn(mock(List.class));
+        int page = 1;
+        Long userId = 23L;
+        Page<CrewDto> crewDtos = new PageImpl<>(List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get()));
+        given(userService.getUserDtoById(anyLong()))
+                .willReturn(createUserDto(userId).build().get());
+        given(crewService.getCrewDtosByRecommendedSort(any(PageRequest.class), any(UserDto.class))
+        ).willReturn(crewDtos);
 
         // when
-        crewFacade.getCrewsByRank(page);
+        crewFacade.getCrewsByRecommendedSort(page, userId);
 
         // then
+        then(userService).should(only())
+                .getUserDtoById(anyLong());
         then(crewService).should(times(1))
-                .getCrewDtosByRank(any());
-        then(crewService).should(times(crewDtos.size()))
+                .getCrewDtosByRecommendedSort(any(PageRequest.class), any(UserDto.class));
+        then(crewService).should(times(crewDtos.getSize()))
                 .getUserImagesByCrew(any(), anyInt());
     }
 
-    @DisplayName("페이지번호를 받으면, 크루추천에 따른 크루 목록을 반환한다.")
+    @DisplayName("페이지를 받으면, 인기순으로 크루목록을 반환한다.")
     @Test
-    void should_GetCrewsByRecommend() {
+    void should_GetCrewsByPopularSort() {
         // given
-        int page = 2;
-        List<CrewDto> crewDtos = List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get());
-        Page<CrewDto> crewDtoPage = new PageImpl<>(crewDtos, PageRequest.of(page, 10), 2);
-        given(crewService.getCrewDtosByRecommend(any()))
-                .willReturn(crewDtoPage);
-        given(crewService.getUserImagesByCrew(any(CrewDto.class), anyInt()))
-                .willReturn(mock(List.class));
+        int page = 1;
+        Page<CrewDto> crewDtos = new PageImpl<>(List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get()));
+        given(crewService.getCrewDtosByPopularSort(any(PageRequest.class)))
+                .willReturn(crewDtos);
 
         // when
-        crewFacade.getCrewsByRecommend(page);
+        crewFacade.getCrewsByPopularSort(page);
 
         // then
         then(crewService).should(times(1))
-                .getCrewDtosByRecommend(any());
-        then(crewService).should(times(crewDtos.size()))
+                .getCrewDtosByPopularSort(any(PageRequest.class));
+        then(crewService).should(times(crewDtos.getSize()))
+                .getUserImagesByCrew(any(), anyInt());
+    }
+
+    @DisplayName("페이지를 받으면, 활동순으로 크루목록을 반환한다.")
+    @Test
+    void should_GetCrewsByActiveSort() {
+        // given
+        int page = 1;
+        Page<CrewDto> crewDtos = new PageImpl<>(List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get()));
+        given(crewService.getCrewDtosByActiveSort(any(PageRequest.class)))
+                .willReturn(crewDtos);
+
+        // when
+        crewFacade.getCrewsByActiveSort(page);
+
+        // then
+        then(crewService).should(times(1))
+                .getCrewDtosByActiveSort(any(PageRequest.class));
+        then(crewService).should(times(crewDtos.getSize()))
+                .getUserImagesByCrew(any(), anyInt());
+    }
+
+    @DisplayName("페이지를 받으면, 최신순으로 크루목록을 반환한다.")
+    @Test
+    void should_GetCrewsByLatestSort() {
+        // given
+        int page = 1;
+        Page<CrewDto> crewDtos = new PageImpl<>(List.of(createCrewDto(3L).build().get(), createCrewDto(4L).build().get()));
+        given(crewService.getCrewDtosByLatestSort(any(PageRequest.class)))
+                .willReturn(crewDtos);
+
+        // when
+        crewFacade.getCrewsByLatestSort(page);
+
+        // then
+        then(crewService).should(times(1))
+                .getCrewDtosByLatestSort(any(PageRequest.class));
+        then(crewService).should(times(crewDtos.getSize()))
                 .getUserImagesByCrew(any(), anyInt());
     }
 

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewServiceImplTest.java
@@ -114,53 +114,104 @@ class CrewServiceImplTest extends ServiceTest {
                 .addCrewMember(anyLong(), anyLong());
     }
 
-    @DisplayName("[getCrewDtosByRank] 페이지와 랭킹에 따른 크루 목록을 가져온다.")
+    @DisplayName("[getCrewDtosByRecommendedSort] 추천순으로 크루 목록을 가져온다.")
     @Test
-    void should_GetCrewDtosByRank() {
+    void should_GetCrewDtosByRecommendedSort() {
         // given
         Pageable pageable = mock(Pageable.class);
+        UserDto userDto = createUserDto().build().get();
         Page<Crew> crews = new PageImpl<>(List.of(
-                createCrew(852L).build().get(),
-                createCrew(159L).build().get(),
-                createCrew(261L).build().get()
+                createCrew(1L).build().get(),
+                createCrew(2L).build().get(),
+                createCrew(3L).build().get()
         ));
-        given(crewReader.getCrewsByRank(pageable))
+        given(crewReader.getCrewsByRecommendedSort(any(Pageable.class), any(CrewGender.class), anyInt()))
                 .willReturn(crews);
         given(crewTagReader.getTagsByCrewId(anyLong()))
                 .willReturn(mock(List.class));
 
         // when
-        crewService.getCrewDtosByRank(pageable);
+        crewService.getCrewDtosByRecommendedSort(pageable, userDto);
 
         // then
         then(crewReader).should(only())
-                .getCrewsByRank(any());
-        then(crewTagReader).should(times(crews.getSize()))
+                .getCrewsByRecommendedSort(any(Pageable.class), any(CrewGender.class), anyInt());
+        then(crewTagReader).should(times(crews.getContent().size()))
                 .getTagsByCrewId(anyLong());
     }
 
-    @DisplayName("[getCrewDtosByRecommend] 페이지와 추천에 따른 크루 목록을 가져온다.")
+    @DisplayName("[getCrewDtosByPopularSort] 인기순으로 크루 목록을 가져온다.")
     @Test
-    void should_GetCrewDtosByRecommend() {
+    void should_GetCrewDtosByPopularSort() {
         // given
         Pageable pageable = mock(Pageable.class);
         Page<Crew> crews = new PageImpl<>(List.of(
-                createCrew(852L).build().get(),
-                createCrew(159L).build().get(),
-                createCrew(261L).build().get()
+                createCrew(1L).build().get(),
+                createCrew(2L).build().get(),
+                createCrew(3L).build().get()
         ));
-        given(crewReader.getCrewsByRecommend(pageable))
+        given(crewReader.getCrewsByPopularSort(pageable))
                 .willReturn(crews);
         given(crewTagReader.getTagsByCrewId(anyLong()))
                 .willReturn(mock(List.class));
 
         // when
-        crewService.getCrewDtosByRecommend(pageable);
+        crewService.getCrewDtosByPopularSort(pageable);
 
         // then
         then(crewReader).should(only())
-                .getCrewsByRecommend(any());
-        then(crewTagReader).should(times(crews.getSize()))
+                .getCrewsByPopularSort(any());
+        then(crewTagReader).should(times(crews.getContent().size()))
+                .getTagsByCrewId(anyLong());
+    }
+
+    @DisplayName("[getCrewDtosByActiveSort] 활동순으로 크루 목록을 가져온다.")
+    @Test
+    void should_GetCrewDtosByActiveSort() {
+        // given
+        Pageable pageable = mock(Pageable.class);
+        Page<Crew> crews = new PageImpl<>(List.of(
+                createCrew(1L).build().get(),
+                createCrew(2L).build().get(),
+                createCrew(3L).build().get()
+        ));
+        given(crewReader.getCrewsByActiveSort(pageable))
+                .willReturn(crews);
+        given(crewTagReader.getTagsByCrewId(anyLong()))
+                .willReturn(mock(List.class));
+
+        // when
+        crewService.getCrewDtosByActiveSort(pageable);
+
+        // then
+        then(crewReader).should(only())
+                .getCrewsByActiveSort(any());
+        then(crewTagReader).should(times(crews.getContent().size()))
+                .getTagsByCrewId(anyLong());
+    }
+
+    @DisplayName("[getCrewDtosByNewestSort] 최신순으로 크루 목록을 가져온다.")
+    @Test
+    void should_GetCrewDtosByNewestSort() {
+        // given
+        Pageable pageable = mock(Pageable.class);
+        Page<Crew> crews = new PageImpl<>(List.of(
+                createCrew(1L).build().get(),
+                createCrew(2L).build().get(),
+                createCrew(3L).build().get()
+        ));
+        given(crewReader.getCrewsByLatestSort(pageable))
+                .willReturn(crews);
+        given(crewTagReader.getTagsByCrewId(anyLong()))
+                .willReturn(mock(List.class));
+
+        // when
+        crewService.getCrewDtosByLatestSort(pageable);
+
+        // then
+        then(crewReader).should(only())
+                .getCrewsByLatestSort(any());
+        then(crewTagReader).should(times(crews.getContent().size()))
                 .getTagsByCrewId(anyLong());
     }
 

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewReader.java
@@ -1,5 +1,6 @@
 package org.orury.domain.crew.domain;
 
+import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,9 +11,13 @@ import java.util.Optional;
 public interface CrewReader {
     Optional<Crew> findById(Long crewId);
 
-    Page<Crew> getCrewsByRank(Pageable pageable);
+    Page<Crew> getCrewsByRecommendedSort(Pageable pageable, CrewGender userGender, int userAge);
 
-    Page<Crew> getCrewsByRecommend(Pageable pageable);
+    Page<Crew> getCrewsByPopularSort(Pageable pageable);
+
+    Page<Crew> getCrewsByActiveSort(Pageable pageable);
+
+    Page<Crew> getCrewsByLatestSort(Pageable pageable);
 
     List<Crew> getJoinedCrewsByUserId(Long userId);
 

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/dto/CrewGender.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/dto/CrewGender.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.orury.domain.global.constants.NumberConstants;
 
+import java.util.Arrays;
+
 @Getter
 @AllArgsConstructor
 public enum CrewGender {
@@ -24,5 +26,11 @@ public enum CrewGender {
             }
         }
         return null;
+    }
+
+    public static CrewGender convertFromUserGender(int userGender) {
+        return Arrays.stream(CrewGender.values())
+                .filter(crewGender -> crewGender.getUserCode() == userGender)
+                .findFirst().get();
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewReaderImpl.java
@@ -2,6 +2,7 @@ package org.orury.domain.crew.infrastructures;
 
 import lombok.RequiredArgsConstructor;
 import org.orury.domain.crew.domain.CrewReader;
+import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,12 +24,23 @@ public class CrewReaderImpl implements CrewReader {
     }
 
     @Override
-    public Page<Crew> getCrewsByRank(Pageable pageable) {
+    public Page<Crew> getCrewsByRecommendedSort(Pageable pageable, CrewGender userGender, int userAge) {
+        List<CrewGender> userGenders = List.of(userGender, CrewGender.ANY);
+        return crewRepository.findAllByGenderIsInAndMinAgeLessThanEqualAndMaxAgeGreaterThanEqualOrderByCreatedAtAsc(userGenders, userAge, userAge, pageable);
+    }
+
+    @Override
+    public Page<Crew> getCrewsByPopularSort(Pageable pageable) {
         return crewRepository.findByOrderByMemberCountDesc(pageable);
     }
 
     @Override
-    public Page<Crew> getCrewsByRecommend(Pageable pageable) {
+    public Page<Crew> getCrewsByActiveSort(Pageable pageable) {
+        return crewRepository.findDistinctCrewsOrderByMeetingCreatedAtDesc(pageable);
+    }
+
+    @Override
+    public Page<Crew> getCrewsByLatestSort(Pageable pageable) {
         return crewRepository.findByOrderByCreatedAtDesc(pageable);
     }
 

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewRepository.java
@@ -1,5 +1,6 @@
 package org.orury.domain.crew.infrastructures;
 
+import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +14,18 @@ public interface CrewRepository extends JpaRepository<Crew, Long> {
 
     Crew getCrewById(Long crewId);
 
+    Page<Crew> findAllByGenderIsInAndMinAgeLessThanEqualAndMaxAgeGreaterThanEqualOrderByCreatedAtAsc(List<CrewGender> userGenders, int userAge1, int userAge2, Pageable pageable);
+
     Page<Crew> findByOrderByMemberCountDesc(Pageable pageable);
 
-    Page<Crew> findByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT c FROM crew c " +
+            "WHERE c.id IN " +
+            "(SELECT m.crew.id FROM crew_meeting m " +
+            "WHERE m.createdAt = (SELECT MAX(m2.createdAt) FROM crew_meeting m2 WHERE m2.crew = m.crew)) " +
+            "ORDER BY (SELECT MAX(m.createdAt) FROM crew_meeting m WHERE m.crew = c) DESC")
+    Page<Crew> findDistinctCrewsOrderByMeetingCreatedAtDesc(Pageable pageable);
 
-    Page<Crew> findAllByIdIn(List<Long> crewIds, Pageable pageable);
+    Page<Crew> findByOrderByCreatedAtDesc(Pageable pageable);
 
     @Modifying
     @Query("UPDATE crew SET memberCount = memberCount + 1 WHERE id = :crewId")

--- a/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewReaderImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/crew/infrastructure/CrewReaderImplTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.orury.domain.config.InfrastructureTest;
+import org.orury.domain.crew.domain.dto.CrewGender;
 import org.orury.domain.crew.domain.entity.CrewApplication;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.springframework.data.domain.Pageable;
@@ -36,22 +37,44 @@ class CrewReaderImplTest extends InfrastructureTest {
                 .findById(anyLong());
     }
 
+    @DisplayName("Pageable, 성별, 나이를 받아, 해당 값이 기준에 충족하는 크루 목록을 조회한다")
+    @Test
+    void getCrewsByRecommended() {
+        // given & when
+        crewReader.getCrewsByRecommendedSort(mock(Pageable.class), mock(CrewGender.class), 27);
+
+        // then
+        then(crewRepository).should(only())
+                .findAllByGenderIsInAndMinAgeLessThanEqualAndMaxAgeGreaterThanEqualOrderByCreatedAtAsc(any(), anyInt(), anyInt(), any());
+    }
+
     @DisplayName("Pageable을 받아, 멤버수 내림차순의 크루 목록을 조회한다")
     @Test
     void getCrewsByRank() {
         // given & when
-        crewReader.getCrewsByRank(mock(Pageable.class));
+        crewReader.getCrewsByPopularSort(mock(Pageable.class));
 
         // then
         then(crewRepository).should(only())
                 .findByOrderByMemberCountDesc(any(Pageable.class));
     }
 
+    @DisplayName("Pageable을 받아, 크루일정 생성일자 최신순의 크루 목록을 조회한다")
+    @Test
+    void getCrewsByActive() {
+        // given & when
+        crewReader.getCrewsByActiveSort(mock(Pageable.class));
+
+        // then
+        then(crewRepository).should(only())
+                .findDistinctCrewsOrderByMeetingCreatedAtDesc(any(Pageable.class));
+    }
+
     @DisplayName("Pageable을 받아, 생성일자 최신순의 크루 목록을 조회한다")
     @Test
     void getCrewsByRecommend() {
         // given & when
-        crewReader.getCrewsByRecommend(mock(Pageable.class));
+        crewReader.getCrewsByLatestSort(mock(Pageable.class));
 
         // then
         then(crewRepository).should(only())


### PR DESCRIPTION
## 개요
아래의 기준으로, 추천순/인기순/활동순/최신순 크루목록 정렬을 구현했습니다.
추천순: 로그인유저의 성별,나이에 부합하는 크루 (생성일자 오래된순)
인기순: 크루멤버수 내림차순
활동순: 크루일정 생성 최신순
최신순: 최신순

- CrewReaderImpl과 CrewRepository에서 주로 구현됐습니다.
- 정원이 다 찬 크루는 제외시킨다는 조건을 만족해주기 위해서는, Spring Data Jpa를 쓰지 못해서, 일단은 반영시키진 않았습니다.
- 활동순으로 구현된 메서드에서 쿼리가 의도한 대로 동작하나, 최적화 했다고는 확신이 없어 해당 쿼리 확인해주시면 감사하겠습니다.
- 테스트코드는 익일 반영하겠습니다.

closed #432

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
