### PR TITLE
Fix : 운영시간이 null인 경우 오류 수정 및 요일 정렬 처리

### DIFF
--- a/orury-client/src/main/java/org/orury/client/gym/interfaces/response/GymResponse.java
+++ b/orury-client/src/main/java/org/orury/client/gym/interfaces/response/GymResponse.java
@@ -4,10 +4,7 @@ import org.orury.domain.global.constants.Constants;
 import org.orury.domain.gym.domain.dto.GymDto;
 
 import java.time.format.TextStyle;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public record GymResponse(
@@ -25,7 +22,7 @@ public record GymResponse(
         String instagramLink,
         String homepageLink,
         String settingDay,
-        Set<Map.Entry<String, String>> businessHours,
+        List<Map.Entry<String, String>> businessHours,
         boolean doingBusiness,
         boolean isLike,
         String gymType,
@@ -38,9 +35,26 @@ public record GymResponse(
             boolean isLike,
             GymReviewStatistics gymReviewStatistics
     ) {
-        Set<Map.Entry<String, String>> koreanBusinessHours = gymDto.businessHours().entrySet().stream()
-                .map(entry -> Map.entry(entry.getKey().getDisplayName(TextStyle.NARROW, Locale.KOREAN), entry.getValue()))
-                .collect(Collectors.toSet());
+
+        // 요일별 순서를 정의
+        Map<String, Integer> dayOrder = Map.of(
+                "월", 1,
+                "화", 2,
+                "수", 3,
+                "목", 4,
+                "금", 5,
+                "토", 6,
+                "일", 7
+        );
+
+        List<Map.Entry<String, String>> koreanBusinessHours = gymDto.businessHours().entrySet().stream()
+                .map(entry -> {
+                    // 운영시간이 null인 값은 null로 보내주기
+                    String key = entry.getKey() == null ? null : entry.getKey().getDisplayName(TextStyle.NARROW, Locale.KOREAN);
+                    return new AbstractMap.SimpleEntry<>(key, entry.getValue());
+                })
+                .sorted(Comparator.comparingInt(entry -> dayOrder.getOrDefault(entry.getKey(), 0)))
+                .collect(Collectors.toList());
 
         return new GymResponse(
                 gymDto.id(),

--- a/orury-client/src/main/java/org/orury/client/gym/interfaces/response/GymResponse.java
+++ b/orury-client/src/main/java/org/orury/client/gym/interfaces/response/GymResponse.java
@@ -4,8 +4,9 @@ import org.orury.domain.global.constants.Constants;
 import org.orury.domain.gym.domain.dto.GymDto;
 
 import java.time.format.TextStyle;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Locale;
 
 public record GymResponse(
         Long id,
@@ -22,7 +23,7 @@ public record GymResponse(
         String instagramLink,
         String homepageLink,
         String settingDay,
-        List<Map.Entry<String, String>> businessHours,
+        List<AbstractMap.SimpleEntry<String, String>> businessHours,
         boolean doingBusiness,
         boolean isLike,
         String gymType,
@@ -35,26 +36,9 @@ public record GymResponse(
             boolean isLike,
             GymReviewStatistics gymReviewStatistics
     ) {
-
-        // 요일별 순서를 정의
-        Map<String, Integer> dayOrder = Map.of(
-                "월", 1,
-                "화", 2,
-                "수", 3,
-                "목", 4,
-                "금", 5,
-                "토", 6,
-                "일", 7
-        );
-
-        List<Map.Entry<String, String>> koreanBusinessHours = gymDto.businessHours().entrySet().stream()
-                .map(entry -> {
-                    // 운영시간이 null인 값은 null로 보내주기
-                    String key = entry.getKey() == null ? null : entry.getKey().getDisplayName(TextStyle.NARROW, Locale.KOREAN);
-                    return new AbstractMap.SimpleEntry<>(key, entry.getValue());
-                })
-                .sorted(Comparator.comparingInt(entry -> dayOrder.getOrDefault(entry.getKey(), 0)))
-                .collect(Collectors.toList());
+        List<AbstractMap.SimpleEntry<String, String>> koreanBusinessHours = gymDto.businessHours().entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey().getDisplayName(TextStyle.NARROW, Locale.KOREAN), entry.getValue()))
+                .toList();
 
         return new GymResponse(
                 gymDto.id(),


### PR DESCRIPTION
## 개요
암장 조회 시 운영시간이 null이면 해당 암장 조회가 불가능한 이슈가 있었습니다. 이를 해결 + 월화수목금토일 순으로 노출처리 진행했습니다.

### 상세 내용
- Map.entry는 null을 허용하지 않아서, 이를 SimpleEntry라는 친구로 바꿨습니다. 얘는 null을 허용해주는 Entry 클래스라고 하네요.
- 정렬의 경우 월화수목금토일 별로 int값을 가지는 map을 선언해주고, 이 친구와 comparingInt 하는 방식으로 정렬처리했습니다.. 더 좋은 방법이 있다면 지적 부탁드립니다.

closed #435 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
