### PR TITLE
Feat : 크루 생성 시, 크루 id 반환

### DIFF
--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
@@ -36,9 +36,9 @@ public class CrewFacade {
     public CrewIdResponse createCrew(CrewRequest request, MultipartFile image, Long userId) {
         var userDto = userService.getUserDtoById(userId);
         var crewDto = request.toDto(userDto);
-        var saveCrewDto = crewService.createCrew(crewDto, image);
+        var crewId = crewService.createCrew(crewDto, image);
 
-        return CrewIdResponse.of(saveCrewDto);
+        return CrewIdResponse.of(crewId);
     }
 
     public Page<CrewsResponse> getCrewsByRecommendedSort(int page, Long userId) {

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewFacade.java
@@ -1,10 +1,14 @@
 package org.orury.client.crew.application;
 
-import lombok.RequiredArgsConstructor;
+import static org.orury.domain.global.constants.NumberConstants.CREW_PAGINATION_SIZE;
+import static org.orury.domain.global.constants.NumberConstants.MAXIMUM_OF_CREW_DETAIL_THUMBNAILS;
+import static org.orury.domain.global.constants.NumberConstants.MAXIMUM_OF_CREW_LIST_THUMBNAILS;
+
 import org.apache.commons.lang3.function.TriFunction;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.client.crew.interfaces.request.CrewRequest;
 import org.orury.client.crew.interfaces.response.CrewApplicantsResponse;
+import org.orury.client.crew.interfaces.response.CrewIdResponse;
 import org.orury.client.crew.interfaces.response.CrewMembersResponse;
 import org.orury.client.crew.interfaces.response.CrewResponse;
 import org.orury.client.crew.interfaces.response.CrewsResponse;
@@ -21,7 +25,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import static org.orury.domain.global.constants.NumberConstants.*;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -29,10 +33,12 @@ public class CrewFacade {
     private final CrewService crewService;
     private final UserService userService;
 
-    public void createCrew(CrewRequest request, MultipartFile image, Long userId) {
+    public CrewIdResponse createCrew(CrewRequest request, MultipartFile image, Long userId) {
         var userDto = userService.getUserDtoById(userId);
         var crewDto = request.toDto(userDto);
-        crewService.createCrew(crewDto, image);
+        var saveCrewDto = crewService.createCrew(crewDto, image);
+
+        return CrewIdResponse.of(saveCrewDto);
     }
 
     public Page<CrewsResponse> getCrewsByRecommendedSort(int page, Long userId) {

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface CrewService {
     CrewDto getCrewDtoById(Long crewId);
 
-    CrewDto createCrew(CrewDto crewDto, MultipartFile image);
+    Long createCrew(CrewDto crewDto, MultipartFile image);
 
     Page<CrewDto> getCrewDtosByRecommendedSort(Pageable pageable, UserDto userDto);
 

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface CrewService {
     CrewDto getCrewDtoById(Long crewId);
 
-    void createCrew(CrewDto crewDto, MultipartFile image);
+    CrewDto createCrew(CrewDto crewDto, MultipartFile image);
 
     Page<CrewDto> getCrewDtosByRecommendedSort(Pageable pageable, UserDto userDto);
 

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -1,6 +1,7 @@
 package org.orury.client.crew.application;
 
-import lombok.RequiredArgsConstructor;
+import static org.orury.common.util.S3Folder.CREW;
+
 import org.orury.client.crew.application.policy.CrewApplicationPolicy;
 import org.orury.client.crew.application.policy.CrewCreatePolicy;
 import org.orury.client.crew.application.policy.CrewPolicy;
@@ -9,7 +10,14 @@ import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.common.error.code.CrewErrorCode;
 import org.orury.common.error.exception.BusinessException;
 import org.orury.common.util.AgeUtils;
-import org.orury.domain.crew.domain.*;
+import org.orury.domain.crew.domain.CrewApplicationReader;
+import org.orury.domain.crew.domain.CrewApplicationStore;
+import org.orury.domain.crew.domain.CrewMemberReader;
+import org.orury.domain.crew.domain.CrewMemberStore;
+import org.orury.domain.crew.domain.CrewReader;
+import org.orury.domain.crew.domain.CrewStore;
+import org.orury.domain.crew.domain.CrewTagReader;
+import org.orury.domain.crew.domain.CrewTagStore;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
@@ -33,7 +41,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.orury.common.util.S3Folder.CREW;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -68,12 +76,13 @@ public class CrewServiceImpl implements CrewService {
 
     @Override
     @Transactional
-    public void createCrew(CrewDto crewDto, MultipartFile file) {
+    public CrewDto createCrew(CrewDto crewDto, MultipartFile file) {
         crewCreatePolicy.validate(crewDto);
         var icon = imageStore.upload(CREW, file);
         Crew crew = crewStore.save(crewDto.toEntity(icon));
         crewTagStore.addTags(crew, crewDto.tags());
         crewMemberStore.addCrewMember(crew.getId(), crew.getUser().getId());
+        return CrewDto.from(crew);
     }
 
     @Override

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -76,13 +76,13 @@ public class CrewServiceImpl implements CrewService {
 
     @Override
     @Transactional
-    public CrewDto createCrew(CrewDto crewDto, MultipartFile file) {
+    public Long createCrew(CrewDto crewDto, MultipartFile file) {
         crewCreatePolicy.validate(crewDto);
         var icon = imageStore.upload(CREW, file);
         Crew crew = crewStore.save(crewDto.toEntity(icon));
         crewTagStore.addTags(crew, crewDto.tags());
         crewMemberStore.addCrewMember(crew.getId(), crew.getUser().getId());
-        return CrewDto.from(crew);
+        return crew.getId();
     }
 
     @Override

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/CrewController.java
@@ -1,13 +1,10 @@
 package org.orury.client.crew.interfaces;
 
-import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.orury.client.crew.application.CrewFacade;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.client.crew.interfaces.request.CrewRequest;
 import org.orury.client.crew.interfaces.response.CrewApplicantsResponse;
+import org.orury.client.crew.interfaces.response.CrewIdResponse;
 import org.orury.client.crew.interfaces.response.CrewMembersResponse;
 import org.orury.client.crew.interfaces.response.CrewResponse;
 import org.orury.client.crew.interfaces.response.CrewsResponse;
@@ -15,10 +12,24 @@ import org.orury.domain.base.converter.ApiResponse;
 import org.orury.domain.user.domain.dto.UserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,9 +45,8 @@ public class CrewController {
             @RequestPart(required = false) MultipartFile image,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        crewFacade.createCrew(request, image, userPrincipal.id());
-
-        return ApiResponse.of(CrewMessage.CREW_CREATED.getMessage());
+        CrewIdResponse response = crewFacade.createCrew(request, image, userPrincipal.id());
+        return ApiResponse.of(CrewMessage.CREW_CREATED.getMessage(), response);
     }
 
     @Operation(summary = "크루 추천순 조회", description = "크루를 추천 순으로 조회한다.")

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/request/CrewRequest.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/request/CrewRequest.java
@@ -1,9 +1,5 @@
 package org.orury.client.crew.interfaces.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import org.apache.logging.log4j.util.Strings;
 import org.hibernate.validator.constraints.Length;
 import org.orury.domain.crew.domain.dto.CrewDto;
@@ -15,6 +11,11 @@ import org.orury.domain.global.validation.EnumValues;
 import org.orury.domain.user.domain.dto.UserDto;
 
 import java.util.List;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 public record CrewRequest(
         @Length(min = 3, max = 15, message = "크루명은 3~15 글자수로 설정 가능합니다.")

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewIdResponse.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewIdResponse.java
@@ -1,0 +1,13 @@
+package org.orury.client.crew.interfaces.response;
+
+import org.orury.domain.crew.domain.dto.CrewDto;
+
+public record CrewIdResponse(
+        Long id
+) {
+    public static CrewIdResponse of(CrewDto crewDto) {
+        return new CrewIdResponse(
+                crewDto.id()
+        );
+    }
+}

--- a/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewIdResponse.java
+++ b/orury-client/src/main/java/org/orury/client/crew/interfaces/response/CrewIdResponse.java
@@ -1,13 +1,11 @@
 package org.orury.client.crew.interfaces.response;
 
-import org.orury.domain.crew.domain.dto.CrewDto;
-
 public record CrewIdResponse(
-        Long id
+        Long crewId
 ) {
-    public static CrewIdResponse of(CrewDto crewDto) {
+    public static CrewIdResponse of(Long id) {
         return new CrewIdResponse(
-                crewDto.id()
+                id
         );
     }
 }

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
@@ -1,5 +1,18 @@
 package org.orury.client.crew.application;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.anyBoolean;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.Mockito.only;
+import static org.orury.client.ClientFixtureFactory.TestCrewRequest.createCrewRequest;
+import static org.orury.domain.CrewDomainFixture.TestCrewDto.createCrewDto;
+import static org.orury.domain.UserDomainFixture.TestUserDto.createUserDto;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.orury.client.config.FacadeTest;
@@ -14,14 +27,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.only;
-import static org.orury.client.ClientFixtureFactory.TestCrewRequest.createCrewRequest;
-import static org.orury.domain.CrewDomainFixture.TestCrewDto.createCrewDto;
-import static org.orury.domain.UserDomainFixture.TestUserDto.createUserDto;
-
 @DisplayName("[Facade] 크루 Facade 테스트")
 class CrewFacadeTest extends FacadeTest {
 
@@ -32,9 +37,16 @@ class CrewFacadeTest extends FacadeTest {
         CrewRequest request = createCrewRequest().build().get();
         MultipartFile image = mock(MultipartFile.class);
         Long userId = 1L;
+        Long crewId = 1L;
+
         UserDto userDto = createUserDto(userId).build().get();
+        CrewDto crewDto = createCrewDto(crewId).build().get();
+
         given(userService.getUserDtoById(anyLong()))
                 .willReturn(userDto);
+        given(crewService.createCrew(any(), any()))
+                .willReturn(crewDto);
+
 
         // when
         crewFacade.createCrew(request, image, userId);

--- a/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
+++ b/orury-client/src/test/java/org/orury/client/crew/application/CrewFacadeTest.java
@@ -40,12 +40,11 @@ class CrewFacadeTest extends FacadeTest {
         Long crewId = 1L;
 
         UserDto userDto = createUserDto(userId).build().get();
-        CrewDto crewDto = createCrewDto(crewId).build().get();
 
         given(userService.getUserDtoById(anyLong()))
                 .willReturn(userDto);
         given(crewService.createCrew(any(), any()))
-                .willReturn(crewDto);
+                .willReturn(crewId);
 
 
         // when


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
크루 생성 후 크루 상세 페이지에 접속하기 위해 크루 id가 필요하다는 요청에 따라, 크루 생성 api를 수정했습니다.

기존
- 각 계층의 생성 메서드에 반환 값 없음 (void)
변경 후
- 각 계층에서 Long (crewId 반환)
- Facade에서 CrewIdResponse에 담아서 반환함

++) 이미 각 생성 메서드에 대해 테스트 코드가 있고, 반환값에 대해 검증을 할 여지가 없는 것 같아 테스트코드는 따로 작성하지 않았습니다 !


closed #431

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
