### PR TITLE
Feat : 다가오는 크루일정 (조회/세팅조회/세팅수정) 구현

### DIFF
--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -3,6 +3,7 @@ package org.orury.client.crew.application;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
+import org.orury.domain.crew.domain.dto.CrewMemberDto;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.springframework.data.domain.Page;
@@ -60,4 +61,6 @@ public interface CrewService {
     List<CrewApplicationDto> getApplicantsByCrew(Long crewId, Long userId);
 
     CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId);
+
+    void updateMeetingViewed(CrewMemberDto crewMemberDto);
 }

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewService.java
@@ -3,6 +3,7 @@ package org.orury.client.crew.application;
 import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
+import org.orury.domain.crew.domain.entity.CrewMember;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -57,4 +58,6 @@ public interface CrewService {
     List<UserDto> getMembersByCrew(Long crewId, Long userId);
 
     List<CrewApplicationDto> getApplicantsByCrew(Long crewId, Long userId);
+
+    CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId);
 }

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -1,7 +1,6 @@
 package org.orury.client.crew.application;
 
-import static org.orury.common.util.S3Folder.CREW;
-
+import lombok.RequiredArgsConstructor;
 import org.orury.client.crew.application.policy.CrewApplicationPolicy;
 import org.orury.client.crew.application.policy.CrewCreatePolicy;
 import org.orury.client.crew.application.policy.CrewPolicy;
@@ -10,14 +9,7 @@ import org.orury.client.crew.interfaces.message.CrewMessage;
 import org.orury.common.error.code.CrewErrorCode;
 import org.orury.common.error.exception.BusinessException;
 import org.orury.common.util.AgeUtils;
-import org.orury.domain.crew.domain.CrewApplicationReader;
-import org.orury.domain.crew.domain.CrewApplicationStore;
-import org.orury.domain.crew.domain.CrewMemberReader;
-import org.orury.domain.crew.domain.CrewMemberStore;
-import org.orury.domain.crew.domain.CrewReader;
-import org.orury.domain.crew.domain.CrewStore;
-import org.orury.domain.crew.domain.CrewTagReader;
-import org.orury.domain.crew.domain.CrewTagStore;
+import org.orury.domain.crew.domain.*;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
@@ -41,7 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import lombok.RequiredArgsConstructor;
+import static org.orury.common.util.S3Folder.CREW;
 
 @Service
 @RequiredArgsConstructor
@@ -260,6 +252,12 @@ public class CrewServiceImpl implements CrewService {
                     User user = userReader.getUserById(crewApplication.getCrewApplicationPK().getUserId());
                     return CrewApplicationDto.from(crewApplication, UserDto.from(user));
                 }).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId) {
+        return crewMemberReader.getCrewMemberByCrewIdAndUserId(crewId, userId);
     }
 
     private void removeMember(Long crewId, Long memberId) {

--- a/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/crew/application/CrewServiceImpl.java
@@ -13,6 +13,7 @@ import org.orury.domain.crew.domain.*;
 import org.orury.domain.crew.domain.dto.CrewApplicationDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.crew.domain.dto.CrewGender;
+import org.orury.domain.crew.domain.dto.CrewMemberDto;
 import org.orury.domain.crew.domain.entity.Crew;
 import org.orury.domain.crew.domain.entity.CrewMember;
 import org.orury.domain.image.domain.ImageStore;
@@ -258,6 +259,13 @@ public class CrewServiceImpl implements CrewService {
     @Transactional(readOnly = true)
     public CrewMember getCrewMemberByCrewIdAndUserId(Long crewId, Long userId) {
         return crewMemberReader.getCrewMemberByCrewIdAndUserId(crewId, userId);
+    }
+
+    @Override
+    @Transactional
+    public void updateMeetingViewed(CrewMemberDto crewMemberDto) {
+        crewPolicy.validateCrewMember(crewMemberDto.crewMemberPK().getCrewId(), crewMemberDto.crewMemberPK().getUserId());
+        crewMemberStore.updateMeetingViewed(crewMemberDto.toEntity());
     }
 
     private void removeMember(Long crewId, Long memberId) {

--- a/orury-client/src/main/java/org/orury/client/meeting/application/MeetingService.java
+++ b/orury-client/src/main/java/org/orury/client/meeting/application/MeetingService.java
@@ -14,6 +14,8 @@ public interface MeetingService {
 
     List<MeetingDto> getPastMeetingDtosByCrewId(Long crewId, Long userId);
 
+    List<MeetingDto> getUpcomingMeetingDtosByUserId(Long userId);
+
     List<String> getUserImagesByMeeting(MeetingDto meetingDto);
 
     void updateMeeting(MeetingDto meetingDto, Long userId);

--- a/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
@@ -52,7 +52,7 @@ public class MeetingServiceImpl implements MeetingService {
         validateStartTime(meetingDto.startTime());
         validateCapacity(meetingDto.capacity(), meetingDto.crewDto().memberCount());
         Meeting meeting = meetingStore.createMeeting(meetingDto.toEntity());
-        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(meetingDto.userDto().id(), meeting.getId()), true);
+        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(meetingDto.userDto().id(), meeting.getId()));
         meetingMemberStore.addMember(meetingMemberDto.toEntity());
     }
 
@@ -111,7 +111,7 @@ public class MeetingServiceImpl implements MeetingService {
             throw new BusinessException(MeetingErrorCode.ALREADY_JOINED_MEETING);
         if (meetingDto.memberCount() >= meetingDto.capacity())
             throw new BusinessException(MeetingErrorCode.FULL_MEETING);
-        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(userId, meetingDto.id()), true);
+        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(userId, meetingDto.id()));
         meetingMemberStore.addMember(meetingMemberDto.toEntity());
     }
 

--- a/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
@@ -123,8 +123,7 @@ public class MeetingServiceImpl implements MeetingService {
             throw new BusinessException(MeetingErrorCode.MEETING_CREATOR);
         if (!meetingMemberReader.existsByMeetingIdAndUserId(meetingDto.id(), userId))
             throw new BusinessException(MeetingErrorCode.NOT_JOINED_MEETING);
-        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(userId, meetingDto.id()));
-        meetingMemberStore.removeMember(meetingMemberDto.toEntity());
+        meetingMemberStore.removeMember(userId, meetingDto.id());
     }
 
     @Override

--- a/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
@@ -74,6 +74,13 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<MeetingDto> getUpcomingMeetingDtosByUserId(Long userId) {
+        return meetingReader.getUpcomingMeetingsByUserId(userId)
+                .stream().map(MeetingDto::from).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<String> getUserImagesByMeeting(MeetingDto meetingDto) {
         UserDto meetingCreator = meetingDto.userDto();
         List<MeetingMember> otherMembers = meetingMemberReader.getOtherMeetingMembersByMeetingIdMaximum(meetingDto.id(), meetingDto.userDto().id(), NumberConstants.MAXIMUM_OF_MEETING_THUMBNAILS - 1);

--- a/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
+++ b/orury-client/src/main/java/org/orury/client/meeting/application/MeetingServiceImpl.java
@@ -52,7 +52,7 @@ public class MeetingServiceImpl implements MeetingService {
         validateStartTime(meetingDto.startTime());
         validateCapacity(meetingDto.capacity(), meetingDto.crewDto().memberCount());
         Meeting meeting = meetingStore.createMeeting(meetingDto.toEntity());
-        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(meetingDto.userDto().id(), meeting.getId()));
+        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(meetingDto.userDto().id(), meeting.getId()), true);
         meetingMemberStore.addMember(meetingMemberDto.toEntity());
     }
 
@@ -111,7 +111,7 @@ public class MeetingServiceImpl implements MeetingService {
             throw new BusinessException(MeetingErrorCode.ALREADY_JOINED_MEETING);
         if (meetingDto.memberCount() >= meetingDto.capacity())
             throw new BusinessException(MeetingErrorCode.FULL_MEETING);
-        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(userId, meetingDto.id()));
+        MeetingMemberDto meetingMemberDto = MeetingMemberDto.of(MeetingMemberPK.of(userId, meetingDto.id()), true);
         meetingMemberStore.addMember(meetingMemberDto.toEntity());
     }
 

--- a/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
+++ b/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
@@ -5,15 +5,18 @@ import lombok.RequiredArgsConstructor;
 import org.orury.client.comment.application.CommentService;
 import org.orury.client.global.IdIdentifiable;
 import org.orury.client.global.WithCursorResponse;
+import org.orury.client.meeting.application.MeetingService;
 import org.orury.client.post.application.PostService;
 import org.orury.client.review.application.ReviewService;
 import org.orury.client.user.interfaces.request.UserInfoRequest;
 import org.orury.client.user.interfaces.request.UserReportRequest;
 import org.orury.client.user.interfaces.response.MyCommentResponse;
+import org.orury.client.user.interfaces.response.MyMeetingResponse;
 import org.orury.client.user.interfaces.response.MyPostResponse;
 import org.orury.client.user.interfaces.response.MyReviewResponse;
 import org.orury.domain.comment.domain.dto.CommentDto;
 import org.orury.domain.global.constants.NumberConstants;
+import org.orury.domain.meeting.domain.dto.MeetingDto;
 import org.orury.domain.post.domain.dto.PostDto;
 import org.orury.domain.review.domain.dto.ReviewDto;
 import org.orury.domain.user.domain.dto.ReportDto;
@@ -32,6 +35,7 @@ public class UserFacade {
     private final PostService postService;
     private final ReviewService reviewService;
     private final CommentService commentService;
+    private final MeetingService meetingService;
 
     public UserDto readMypage(Long id) {
         return userService.getUserDtoById(id);
@@ -67,6 +71,14 @@ public class UserFacade {
         List<CommentDto> commmentDtos = commentService.getCommentDtosByUserId(id, cursor);
 
         return convertDtosToWithCursorResponse(commmentDtos, MyCommentResponse::of, cursor);
+    }
+
+    public List<MyMeetingResponse> getMeetingsByUserId(Long userId) {
+        List<MeetingDto> meetingDtos = meetingService.getUpcomingMeetingDtosByUserId(userId);
+
+        return meetingDtos.stream()
+                .map(meetingDto -> MyMeetingResponse.of(meetingDto, userId))
+                .toList();
     }
 
     public void deleteUser(Long id) {

--- a/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
+++ b/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
@@ -9,6 +9,7 @@ import org.orury.client.global.WithCursorResponse;
 import org.orury.client.meeting.application.MeetingService;
 import org.orury.client.post.application.PostService;
 import org.orury.client.review.application.ReviewService;
+import org.orury.client.user.interfaces.request.MeetingViewedRequest;
 import org.orury.client.user.interfaces.request.UserInfoRequest;
 import org.orury.client.user.interfaces.response.*;
 import org.orury.client.user.interfaces.request.UserReportRequest;
@@ -18,6 +19,7 @@ import org.orury.client.user.interfaces.response.MyPostResponse;
 import org.orury.client.user.interfaces.response.MyReviewResponse;
 import org.orury.domain.comment.domain.dto.CommentDto;
 import org.orury.domain.crew.domain.dto.CrewDto;
+import org.orury.domain.crew.domain.entity.CrewMemberPK;
 import org.orury.domain.global.constants.NumberConstants;
 import org.orury.domain.meeting.domain.dto.MeetingDto;
 import org.orury.domain.post.domain.dto.PostDto;
@@ -93,6 +95,13 @@ public class UserFacade {
                             .getMeetingViewed();
                     return MyCrewMemberResponse.of(crewDto, meetingViewed);
                 }).toList();
+    }
+
+    public void updateMeetingViewed(Long userId, List<MeetingViewedRequest> requests) {
+        requests.forEach(request -> {
+            CrewMemberPK crewMemberPK = CrewMemberPK.of(userId, request.crewId());
+            crewService.updateMeetingViewed(request.toDto(crewMemberPK));
+        });
     }
 
     public void deleteUser(Long id) {

--- a/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
+++ b/orury-client/src/main/java/org/orury/client/user/application/UserFacade.java
@@ -3,18 +3,21 @@ package org.orury.client.user.application;
 
 import lombok.RequiredArgsConstructor;
 import org.orury.client.comment.application.CommentService;
+import org.orury.client.crew.application.CrewService;
 import org.orury.client.global.IdIdentifiable;
 import org.orury.client.global.WithCursorResponse;
 import org.orury.client.meeting.application.MeetingService;
 import org.orury.client.post.application.PostService;
 import org.orury.client.review.application.ReviewService;
 import org.orury.client.user.interfaces.request.UserInfoRequest;
+import org.orury.client.user.interfaces.response.*;
 import org.orury.client.user.interfaces.request.UserReportRequest;
 import org.orury.client.user.interfaces.response.MyCommentResponse;
 import org.orury.client.user.interfaces.response.MyMeetingResponse;
 import org.orury.client.user.interfaces.response.MyPostResponse;
 import org.orury.client.user.interfaces.response.MyReviewResponse;
 import org.orury.domain.comment.domain.dto.CommentDto;
+import org.orury.domain.crew.domain.dto.CrewDto;
 import org.orury.domain.global.constants.NumberConstants;
 import org.orury.domain.meeting.domain.dto.MeetingDto;
 import org.orury.domain.post.domain.dto.PostDto;
@@ -36,6 +39,7 @@ public class UserFacade {
     private final ReviewService reviewService;
     private final CommentService commentService;
     private final MeetingService meetingService;
+    private final CrewService crewService;
 
     public UserDto readMypage(Long id) {
         return userService.getUserDtoById(id);
@@ -81,6 +85,16 @@ public class UserFacade {
                 .toList();
     }
 
+    public List<MyCrewMemberResponse> getCrewMembersByUserId(Long userId) {
+        List<CrewDto> crewDtos = crewService.getJoinedCrewDtos(userId);
+        return crewDtos.stream()
+                .map(crewDto -> {
+                    Boolean meetingViewed = crewService.getCrewMemberByCrewIdAndUserId(crewDto.id(), userId)
+                            .getMeetingViewed();
+                    return MyCrewMemberResponse.of(crewDto, meetingViewed);
+                }).toList();
+    }
+
     public void deleteUser(Long id) {
         UserDto userDto = userService.getUserDtoById(id);
         userService.deleteUser(userDto);
@@ -100,4 +114,5 @@ public class UserFacade {
 
         return WithCursorResponse.of(responses, cursor);
     }
+
 }

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
@@ -9,16 +9,15 @@ import org.orury.client.user.application.UserFacade;
 import org.orury.client.user.interfaces.message.UserMessage;
 import org.orury.client.user.interfaces.request.UserInfoRequest;
 import org.orury.client.user.interfaces.request.UserReportRequest;
-import org.orury.client.user.interfaces.response.MyCommentResponse;
-import org.orury.client.user.interfaces.response.MyPostResponse;
-import org.orury.client.user.interfaces.response.MyReviewResponse;
-import org.orury.client.user.interfaces.response.MypageResponse;
+import org.orury.client.user.interfaces.response.*;
 import org.orury.domain.base.converter.ApiResponse;
 import org.orury.domain.user.domain.dto.UserDto;
 import org.orury.domain.user.domain.dto.UserPrincipal;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -79,6 +78,14 @@ public class UserController {
         WithCursorResponse<MyCommentResponse> cursorResponse = userFacade.getCommentsByUserId(userPrincipal.id(), cursor);
 
         return ApiResponse.of(UserMessage.USER_COMMENTS_READ.getMessage(), cursorResponse);
+    }
+
+    @Operation(summary = "다가오는 크루일정 조회", description = "user_id로 다가오는 크루일정 목록을 조회한다.")
+    @GetMapping("/meetings")
+    public ApiResponse getMeetingsByUserId(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<MyMeetingResponse> response = userFacade.getMeetingsByUserId(userPrincipal.id());
+
+        return ApiResponse.of(UserMessage.USER_MEETINGS_READ.getMessage(), response);
     }
 
     @Operation(summary = "회원 탈퇴", description = "id에 해당하는 회원을 탈퇴합니다. ")

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
@@ -92,9 +92,9 @@ public class UserController {
     @Operation(summary = "크루일정 조회여부 조회", description = "user_id로 가입된 크루들과 각각의 크루일정 조회여부를 조회한다.")
     @GetMapping("/meetings/view-settings")
     public ApiResponse getCrewMembersByUserId(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        List<MyCrewMemberResponse> response = userFacade.getCrewMembersByUserId(userPrincipal.id());
+        List<MyCrewMemberResponse> responses = userFacade.getCrewMembersByUserId(userPrincipal.id());
 
-        return ApiResponse.of(UserMessage.USER_CREW_MEMBERS_READ.getMessage(), response);
+        return ApiResponse.of(UserMessage.USER_CREW_MEMBERS_READ.getMessage(), responses);
     }
 
     @Operation(summary = "크루일정 조회여부 수정", description = "가입된 크루들 각각의 크루일정 조회여부를 수정한다.")

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.orury.client.global.WithCursorResponse;
 import org.orury.client.user.application.UserFacade;
 import org.orury.client.user.interfaces.message.UserMessage;
+import org.orury.client.user.interfaces.request.MeetingViewedRequest;
 import org.orury.client.user.interfaces.request.UserInfoRequest;
 import org.orury.client.user.interfaces.request.UserReportRequest;
 import org.orury.client.user.interfaces.response.*;
@@ -96,6 +97,13 @@ public class UserController {
         return ApiResponse.of(UserMessage.USER_CREW_MEMBERS_READ.getMessage(), response);
     }
 
+    @Operation(summary = "크루일정 조회여부 수정", description = "가입된 크루들 각각의 크루일정 조회여부를 수정한다.")
+    @PatchMapping("/meetings/view-settings")
+    public ApiResponse updateMeetingViewed(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody List<MeetingViewedRequest> requests) {
+        userFacade.updateMeetingViewed(userPrincipal.id(), requests);
+
+        return ApiResponse.of(UserMessage.USER_MEETING_VIEWED_UPDATED.getMessage());
+    }
 
     @Operation(summary = "회원 탈퇴", description = "id에 해당하는 회원을 탈퇴합니다. ")
     @DeleteMapping

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/UserController.java
@@ -88,6 +88,15 @@ public class UserController {
         return ApiResponse.of(UserMessage.USER_MEETINGS_READ.getMessage(), response);
     }
 
+    @Operation(summary = "크루일정 조회여부 조회", description = "user_id로 가입된 크루들과 각각의 크루일정 조회여부를 조회한다.")
+    @GetMapping("/meetings/view-settings")
+    public ApiResponse getCrewMembersByUserId(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<MyCrewMemberResponse> response = userFacade.getCrewMembersByUserId(userPrincipal.id());
+
+        return ApiResponse.of(UserMessage.USER_CREW_MEMBERS_READ.getMessage(), response);
+    }
+
+
     @Operation(summary = "회원 탈퇴", description = "id에 해당하는 회원을 탈퇴합니다. ")
     @DeleteMapping
     public ApiResponse deleteUser(@AuthenticationPrincipal UserPrincipal userPrincipal) {

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
@@ -12,6 +12,7 @@ public enum UserMessage {
     USER_POSTS_READ("작성한 게시글을 조회했습니다."),
     USER_COMMENTS_READ("작성한 댓글을 조회했습니다."),
     USER_REVIEWS_READ("작성한 리뷰를 조회했습니다."),
+    USER_MEETINGS_READ("다가오는 크루 일정을 조회했습니다."),
     USER_REPORTED("신고가 완료되었습니다.");
 
     private final String message;

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
@@ -13,13 +13,9 @@ public enum UserMessage {
     USER_COMMENTS_READ("작성한 댓글을 조회했습니다."),
     USER_REVIEWS_READ("작성한 리뷰를 조회했습니다."),
     USER_CREW_MEMBERS_READ("크루 일정 조회여부를 조회했습니다."),
+    USER_MEETING_VIEWED_UPDATED("크루 일정 조회여부를 수정했습니다."),
     USER_MEETINGS_READ("다가오는 크루 일정을 조회했습니다."),
-<<<<<<< HEAD
     USER_REPORTED("신고가 완료되었습니다.");
-=======
-    USER_CREW_MEMBERS_READ("크루 일정 조회여부를 조회했습니다."),
-    USER_MEETING_VIEWED_UPDATED("크루 일정 조회여부를 수정했습니다.");
->>>>>>> 51fec3ba (feat : 마이페이지의 다가오는일정 크루별 조회여부 수정 구현)
 
     private final String message;
 

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
@@ -14,7 +14,12 @@ public enum UserMessage {
     USER_REVIEWS_READ("작성한 리뷰를 조회했습니다."),
     USER_CREW_MEMBERS_READ("크루 일정 조회여부를 조회했습니다."),
     USER_MEETINGS_READ("다가오는 크루 일정을 조회했습니다."),
+<<<<<<< HEAD
     USER_REPORTED("신고가 완료되었습니다.");
+=======
+    USER_CREW_MEMBERS_READ("크루 일정 조회여부를 조회했습니다."),
+    USER_MEETING_VIEWED_UPDATED("크루 일정 조회여부를 수정했습니다.");
+>>>>>>> 51fec3ba (feat : 마이페이지의 다가오는일정 크루별 조회여부 수정 구현)
 
     private final String message;
 

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/message/UserMessage.java
@@ -12,6 +12,7 @@ public enum UserMessage {
     USER_POSTS_READ("작성한 게시글을 조회했습니다."),
     USER_COMMENTS_READ("작성한 댓글을 조회했습니다."),
     USER_REVIEWS_READ("작성한 리뷰를 조회했습니다."),
+    USER_CREW_MEMBERS_READ("크루 일정 조회여부를 조회했습니다."),
     USER_MEETINGS_READ("다가오는 크루 일정을 조회했습니다."),
     USER_REPORTED("신고가 완료되었습니다.");
 

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/request/MeetingViewedRequest.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/request/MeetingViewedRequest.java
@@ -1,0 +1,17 @@
+package org.orury.client.user.interfaces.request;
+
+import org.orury.domain.crew.domain.dto.CrewMemberDto;
+import org.orury.domain.crew.domain.entity.CrewMemberPK;
+
+public record MeetingViewedRequest(
+        Long crewId,
+        boolean meetingViewed
+) {
+    public static MeetingViewedRequest of(Long crewId, boolean meetingViewed) {
+        return new MeetingViewedRequest(crewId, meetingViewed);
+    }
+
+    public CrewMemberDto toDto(CrewMemberPK crewMemberPK) {
+        return CrewMemberDto.of(crewMemberPK, meetingViewed, null, null);
+    }
+}

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/response/MyCrewMemberResponse.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/response/MyCrewMemberResponse.java
@@ -1,0 +1,29 @@
+package org.orury.client.user.interfaces.response;
+
+import org.orury.domain.crew.domain.dto.CrewDto;
+
+public record MyCrewMemberResponse(
+        Long crewId,
+        String crewName,
+        Boolean meetingViewed
+) {
+    public static MyCrewMemberResponse of(
+            Long crewId,
+            String crewName,
+            Boolean meetingViewed
+    ) {
+        return new MyCrewMemberResponse(
+                crewId,
+                crewName,
+                meetingViewed
+        );
+    }
+
+    public static MyCrewMemberResponse of(CrewDto crewDto, Boolean meetingViewed) {
+        return MyCrewMemberResponse.of(
+                crewDto.id(),
+                crewDto.name(),
+                meetingViewed
+        );
+    }
+}

--- a/orury-client/src/main/java/org/orury/client/user/interfaces/response/MyMeetingResponse.java
+++ b/orury-client/src/main/java/org/orury/client/user/interfaces/response/MyMeetingResponse.java
@@ -1,0 +1,54 @@
+package org.orury.client.user.interfaces.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.orury.domain.meeting.domain.dto.MeetingDto;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record MyMeetingResponse(
+        Long crewId,
+        String crewName,
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        LocalDateTime startTime,
+        Long gymId,
+        String gymName,
+        int memberCount,
+        int capacity,
+        boolean isCreator
+) {
+    public static MyMeetingResponse of(
+            Long crewId,
+            String crewName,
+            LocalDateTime startTime,
+            Long gymId,
+            String gymName,
+            int memberCount,
+            int capacity,
+            boolean isCreator
+    ) {
+        return new MyMeetingResponse(
+                crewId,
+                crewName,
+                startTime,
+                gymId,
+                gymName,
+                memberCount,
+                capacity,
+                isCreator
+        );
+    }
+
+    public static MyMeetingResponse of(MeetingDto meetingDto, Long userId) {
+        return new MyMeetingResponse(
+                meetingDto.crewDto().id(),
+                meetingDto.crewDto().name(),
+                meetingDto.startTime(),
+                meetingDto.gymDto().id(),
+                meetingDto.gymDto().name(),
+                meetingDto.memberCount(),
+                meetingDto.capacity(),
+                Objects.equals(userId, meetingDto.userDto().id())
+        );
+    }
+}

--- a/orury-client/src/test/java/org/orury/client/config/FacadeTest.java
+++ b/orury-client/src/test/java/org/orury/client/config/FacadeTest.java
@@ -59,7 +59,7 @@ public abstract class FacadeTest {
         meetingService = mock(MeetingService.class);
         notificationService = mock(NotificationService.class);
 
-        userFacade = new UserFacade(userService, postService, reviewService, commentService);
+        userFacade = new UserFacade(userService, postService, reviewService, commentService, meetingService, crewService);
         gymFacade = new GymFacade(gymService, reviewService);
         commentFacade = new CommentFacade(commentService, postService, userService, notificationService);
         crewFacade = new CrewFacade(crewService, userService);

--- a/orury-client/src/test/java/org/orury/client/meeting/application/MeetingServiceImplTest.java
+++ b/orury-client/src/test/java/org/orury/client/meeting/application/MeetingServiceImplTest.java
@@ -585,7 +585,7 @@ class MeetingServiceImplTest extends ServiceTest {
         then(meetingMemberReader).should(only())
                 .existsByMeetingIdAndUserId(anyLong(), anyLong());
         then(meetingMemberStore).should(only())
-                .removeMember(any(MeetingMember.class));
+                .removeMember(anyLong(), anyLong());
     }
 
     @DisplayName("[removeMeetingMember] 크루원이 아니면, NotCrewMember 예외를 반환한다.")
@@ -608,7 +608,7 @@ class MeetingServiceImplTest extends ServiceTest {
         then(meetingMemberReader).should(never())
                 .existsByMeetingIdAndUserId(anyLong(), anyLong());
         then(meetingMemberStore).should(never())
-                .removeMember(any(MeetingMember.class));
+                .removeMember(anyLong(), anyLong());
     }
 
     @DisplayName("[removeMeetingMember] 제거하려는 멤버가 일정 주최자면, MeetingCreator 예외를 반환한다.")
@@ -629,7 +629,7 @@ class MeetingServiceImplTest extends ServiceTest {
         then(meetingMemberReader).should(never())
                 .existsByMeetingIdAndUserId(anyLong(), anyLong());
         then(meetingMemberStore).should(never())
-                .removeMember(any(MeetingMember.class));
+                .removeMember(anyLong(), anyLong());
     }
 
     @DisplayName("[removeMeetingMember] 제거하려는 멤버가 일정에 존재하지 않으면, NotJoinedMeeting 예외를 반환한다.")
@@ -653,7 +653,7 @@ class MeetingServiceImplTest extends ServiceTest {
         then(meetingMemberReader).should(only())
                 .existsByMeetingIdAndUserId(anyLong(), anyLong());
         then(meetingMemberStore).should(never())
-                .removeMember(any(MeetingMember.class));
+                .removeMember(anyLong(), anyLong());
     }
 
     @DisplayName("[getUserDtosByMeeting] 일정dto와 유저id를 받아, 일정에 참여하는 유저Dto 리스트를 반환한다.")

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewMemberStore.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/CrewMemberStore.java
@@ -1,7 +1,11 @@
 package org.orury.domain.crew.domain;
 
+import org.orury.domain.crew.domain.entity.CrewMember;
+
 public interface CrewMemberStore {
     void addCrewMember(Long crewId, Long userId);
 
     void subtractCrewMember(Long crewId, Long userId);
+
+    void updateMeetingViewed(CrewMember crewMember);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/dto/CrewMemberDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/dto/CrewMemberDto.java
@@ -10,16 +10,19 @@ import java.time.LocalDateTime;
  */
 public record CrewMemberDto(
         CrewMemberPK crewMemberPK,
+        Boolean meetingViewed,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static CrewMemberDto of(
             CrewMemberPK crewMemberPK,
+            Boolean meetingViewed,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
         return new CrewMemberDto(
                 crewMemberPK,
+                meetingViewed,
                 createdAt,
                 updatedAt
         );
@@ -28,6 +31,7 @@ public record CrewMemberDto(
     public static CrewMemberDto from(CrewMember crewMember) {
         return CrewMemberDto.of(
                 crewMember.getCrewMemberPK(),
+                crewMember.getMeetingViewed(),
                 crewMember.getCreatedAt(),
                 crewMember.getUpdatedAt()
         );
@@ -36,6 +40,7 @@ public record CrewMemberDto(
     public CrewMember toEntity() {
         return CrewMember.of(
                 crewMemberPK,
+                meetingViewed,
                 createdAt,
                 updatedAt
         );

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/CrewMember.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/CrewMember.java
@@ -1,10 +1,9 @@
 package org.orury.domain.crew.domain.entity;
 
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
+import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.type.NumericBooleanConverter;
 import org.orury.domain.base.db.AuditingField;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -20,6 +19,9 @@ import java.time.LocalDateTime;
 public class CrewMember extends AuditingField {
     @EmbeddedId
     private CrewMemberPK crewMemberPK;
+
+    @Convert(converter = NumericBooleanConverter.class)
+    @Column(name = "meeting_viewed", nullable = false)
     private Boolean meetingViewed;
 
     private CrewMember(

--- a/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/CrewMember.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/domain/entity/CrewMember.java
@@ -20,24 +20,29 @@ import java.time.LocalDateTime;
 public class CrewMember extends AuditingField {
     @EmbeddedId
     private CrewMemberPK crewMemberPK;
+    private Boolean meetingViewed;
 
     private CrewMember(
             CrewMemberPK crewMemberPK,
+            Boolean meetingViewed,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
         this.crewMemberPK = crewMemberPK;
+        this.meetingViewed = meetingViewed;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
     public static CrewMember of(
             CrewMemberPK crewMemberPK,
+            Boolean meetingViewed,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
         return new CrewMember(
                 crewMemberPK,
+                meetingViewed,
                 createdAt,
                 updatedAt
         );

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationStoreImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewApplicationStoreImpl.java
@@ -35,7 +35,7 @@ public class CrewApplicationStoreImpl implements CrewApplicationStore {
 
         Long userId = crewApplicationPK.getUserId();
         Long crewId = crewApplicationPK.getCrewId();
-        CrewMember crewMember = CrewMember.of(CrewMemberPK.of(userId, crewId), null, null);
+        CrewMember crewMember = CrewMember.of(CrewMemberPK.of(userId, crewId), true, null, null);
         crewMemberRepository.save(crewMember);
         crewRepository.increaseMemberCount(crewId);
     }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberRepository.java
@@ -19,4 +19,6 @@ public interface CrewMemberRepository extends JpaRepository<CrewMember, CrewMemb
     List<CrewMember> findByCrewMemberPK_CrewIdAndCrewMemberPK_UserIdNot(Long crewId, Long crewCreatorId, PageRequest pageRequest);
 
     CrewMember getCrewMemberByCrewMemberPK_CrewIdAndCrewMemberPK_UserId(Long crewId, Long userId);
+
+    List<CrewMember> findByCrewMemberPK_UserIdAndMeetingViewedTrue(Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberStoreImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberStoreImpl.java
@@ -14,7 +14,7 @@ public class CrewMemberStoreImpl implements CrewMemberStore {
 
     @Override
     public void addCrewMember(Long crewId, Long userId) {
-        var crewMember = CrewMember.of(CrewMemberPK.of(userId, crewId), null, null);
+        var crewMember = CrewMember.of(CrewMemberPK.of(userId, crewId), true, null, null);
         crewMemberRepository.save(crewMember);
         crewRepository.increaseMemberCount(crewId);
     }

--- a/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberStoreImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/crew/infrastructures/CrewMemberStoreImpl.java
@@ -25,4 +25,9 @@ public class CrewMemberStoreImpl implements CrewMemberStore {
         crewMemberRepository.deleteById(crewMemberPK);
         crewRepository.decreaseMemberCount(crewId);
     }
+
+    @Override
+    public void updateMeetingViewed(CrewMember crewMember) {
+        crewMemberRepository.save(crewMember);
+    }
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/MeetingMemberStore.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/MeetingMemberStore.java
@@ -5,7 +5,7 @@ import org.orury.domain.meeting.domain.entity.MeetingMember;
 public interface MeetingMemberStore {
     void addMember(MeetingMember meetingMember);
 
-    void removeMember(MeetingMember meetingMember);
+    void removeMember(Long userId, Long meetingId);
 
     void removeAllByUserIdAndCrewId(Long userId, Long crewId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/MeetingReader.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/MeetingReader.java
@@ -11,4 +11,6 @@ public interface MeetingReader {
     List<Meeting> getNotStartedMeetingsByCrewId(Long crewId);
 
     List<Meeting> getStartedMeetingsByCrewId(Long crewId);
+
+    List<Meeting> getUpcomingMeetingsByUserId(Long userId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/dto/MeetingMemberDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/dto/MeetingMemberDto.java
@@ -7,18 +7,17 @@ import org.orury.domain.meeting.domain.entity.MeetingMemberPK;
  * DTO for {@link MeetingMember}
  */
 public record MeetingMemberDto(
-        MeetingMemberPK meetingMemberPK,
-        Boolean meetingViewed
+        MeetingMemberPK meetingMemberPK
 ) {
-    public static MeetingMemberDto of(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
-        return new MeetingMemberDto(meetingMemberPK, meetingViewed);
+    public static MeetingMemberDto of(MeetingMemberPK meetingMemberPK) {
+        return new MeetingMemberDto(meetingMemberPK);
     }
 
     public static MeetingMemberDto from(MeetingMember meetingMember) {
-        return MeetingMemberDto.of(meetingMember.getMeetingMemberPK(), meetingMember.getMeetingViewed());
+        return MeetingMemberDto.of(meetingMember.getMeetingMemberPK());
     }
 
     public MeetingMember toEntity() {
-        return MeetingMember.of(meetingMemberPK, meetingViewed);
+        return MeetingMember.of(meetingMemberPK);
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/dto/MeetingMemberDto.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/dto/MeetingMemberDto.java
@@ -7,17 +7,18 @@ import org.orury.domain.meeting.domain.entity.MeetingMemberPK;
  * DTO for {@link MeetingMember}
  */
 public record MeetingMemberDto(
-        MeetingMemberPK meetingMemberPK
+        MeetingMemberPK meetingMemberPK,
+        Boolean meetingViewed
 ) {
-    public static MeetingMemberDto of(MeetingMemberPK meetingMemberPK) {
-        return new MeetingMemberDto(meetingMemberPK);
+    public static MeetingMemberDto of(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
+        return new MeetingMemberDto(meetingMemberPK, meetingViewed);
     }
 
     public static MeetingMemberDto from(MeetingMember meetingMember) {
-        return MeetingMemberDto.of(meetingMember.getMeetingMemberPK());
+        return MeetingMemberDto.of(meetingMember.getMeetingMemberPK(), meetingMember.getMeetingViewed());
     }
 
     public MeetingMember toEntity() {
-        return MeetingMember.of(meetingMemberPK);
+        return MeetingMember.of(meetingMemberPK, meetingViewed);
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/entity/MeetingMember.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/entity/MeetingMember.java
@@ -1,10 +1,12 @@
 package org.orury.domain.meeting.domain.entity;
 
+import jakarta.persistence.Convert;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.type.NumericBooleanConverter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Slf4j
@@ -18,11 +20,15 @@ public class MeetingMember {
     @EmbeddedId
     private MeetingMemberPK meetingMemberPK;
 
-    private MeetingMember(MeetingMemberPK meetingMemberPK) {
+    @Convert(converter = NumericBooleanConverter.class)
+    private Boolean meetingViewed;
+
+    private MeetingMember(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
         this.meetingMemberPK = meetingMemberPK;
+        this.meetingViewed = meetingViewed;
     }
 
-    public static MeetingMember of(MeetingMemberPK meetingMemberPK) {
-        return new MeetingMember(meetingMemberPK);
+    public static MeetingMember of(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
+        return new MeetingMember(meetingMemberPK, meetingViewed);
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/domain/entity/MeetingMember.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/domain/entity/MeetingMember.java
@@ -1,12 +1,10 @@
 package org.orury.domain.meeting.domain.entity;
 
-import jakarta.persistence.Convert;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.type.NumericBooleanConverter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Slf4j
@@ -20,15 +18,11 @@ public class MeetingMember {
     @EmbeddedId
     private MeetingMemberPK meetingMemberPK;
 
-    @Convert(converter = NumericBooleanConverter.class)
-    private Boolean meetingViewed;
-
-    private MeetingMember(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
+    private MeetingMember(MeetingMemberPK meetingMemberPK) {
         this.meetingMemberPK = meetingMemberPK;
-        this.meetingViewed = meetingViewed;
     }
 
-    public static MeetingMember of(MeetingMemberPK meetingMemberPK, Boolean meetingViewed) {
-        return new MeetingMember(meetingMemberPK, meetingViewed);
+    public static MeetingMember of(MeetingMemberPK meetingMemberPK) {
+        return new MeetingMember(meetingMemberPK);
     }
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingMemberRepository.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingMemberRepository.java
@@ -16,4 +16,6 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Me
     List<MeetingMember> findByMeetingMemberPK_MeetingIdAndMeetingMemberPK_UserIdNot(Long meetingId, Long meetingCreatorId, PageRequest pageRequest);
 
     List<MeetingMember> findByMeetingMemberPK_MeetingId(Long meetingId);
+
+    void deleteByMeetingMemberPK_UserIdAndMeetingMemberPK_MeetingId(Long userId, Long meetingId);
 }

--- a/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingMemberStoreImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingMemberStoreImpl.java
@@ -21,9 +21,9 @@ public class MeetingMemberStoreImpl implements MeetingMemberStore {
     }
 
     @Override
-    public void removeMember(MeetingMember meetingMember) {
-        meetingMemberRepository.delete(meetingMember);
-        meetingRepository.decreaseMemberCount(meetingMember.getMeetingMemberPK().getMeetingId());
+    public void removeMember(Long userId, Long meetingId) {
+        meetingMemberRepository.deleteByMeetingMemberPK_UserIdAndMeetingMemberPK_MeetingId(userId, meetingId);
+        meetingRepository.decreaseMemberCount(meetingId);
     }
 
     @Override

--- a/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingReaderImpl.java
@@ -35,10 +35,9 @@ public class MeetingReaderImpl implements MeetingReader {
 
     @Override
     public List<Meeting> getUpcomingMeetingsByUserId(Long userId) {
-        List<Long> meetingViewedTrueCrewIds = crewMemberRepository.findByCrewMemberPK_UserIdAndMeetingViewedTrue(userId)
-                .stream().map(crewMember -> crewMember.getCrewMemberPK().getCrewId()).toList();
         List<Meeting> upcomingMeetings = new LinkedList<>();
-        meetingViewedTrueCrewIds.stream()
+        crewMemberRepository.findByCrewMemberPK_UserIdAndMeetingViewedTrue(userId).stream()
+                .map(crewMember -> crewMember.getCrewMemberPK().getCrewId())
                 .map(crewId -> meetingRepository.findByCrew_IdAndStartTimeAfterOrderByIdDesc(crewId, LocalDateTime.now()))
                 .map(meetings -> meetings.stream()
                         .filter(meeting -> meetingMemberRepository.existsByMeetingMemberPK_MeetingIdAndMeetingMemberPK_UserId(meeting.getId(), userId))

--- a/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingReaderImpl.java
+++ b/orury-domain/src/main/java/org/orury/domain/meeting/infrastructure/MeetingReaderImpl.java
@@ -1,11 +1,13 @@
 package org.orury.domain.meeting.infrastructure;
 
 import lombok.RequiredArgsConstructor;
+import org.orury.domain.crew.infrastructures.CrewMemberRepository;
 import org.orury.domain.meeting.domain.MeetingReader;
 import org.orury.domain.meeting.domain.entity.Meeting;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,6 +15,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MeetingReaderImpl implements MeetingReader {
     private final MeetingRepository meetingRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
+    private final CrewMemberRepository crewMemberRepository;
 
     @Override
     public Optional<Meeting> findById(Long meetingId) {
@@ -27,5 +31,18 @@ public class MeetingReaderImpl implements MeetingReader {
     @Override
     public List<Meeting> getStartedMeetingsByCrewId(Long crewId) {
         return meetingRepository.findByCrew_IdAndStartTimeBeforeOrderByIdDesc(crewId, LocalDateTime.now());
+    }
+
+    @Override
+    public List<Meeting> getUpcomingMeetingsByUserId(Long userId) {
+        List<Long> meetingViewedTrueCrewIds = crewMemberRepository.findByCrewMemberPK_UserIdAndMeetingViewedTrue(userId)
+                .stream().map(crewMember -> crewMember.getCrewMemberPK().getCrewId()).toList();
+        List<Meeting> upcomingMeetings = new LinkedList<>();
+        meetingViewedTrueCrewIds.stream()
+                .map(crewId -> meetingRepository.findByCrew_IdAndStartTimeAfterOrderByIdDesc(crewId, LocalDateTime.now()))
+                .map(meetings -> meetings.stream()
+                        .filter(meeting -> meetingMemberRepository.existsByMeetingMemberPK_MeetingIdAndMeetingMemberPK_UserId(meeting.getId(), userId))
+                ).forEach(meetings -> upcomingMeetings.addAll(meetings.toList()));
+        return upcomingMeetings;
     }
 }

--- a/orury-domain/src/main/resources/db/migration/V1.0.37__add_meeting_viewed_column.sql
+++ b/orury-domain/src/main/resources/db/migration/V1.0.37__add_meeting_viewed_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `crew_member`
-    ADD COLUMN meeting_viewed TINYINT(1) NOT NULL;

--- a/orury-domain/src/main/resources/db/migration/V1.0.37__add_meeting_viewed_column.sql
+++ b/orury-domain/src/main/resources/db/migration/V1.0.37__add_meeting_viewed_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `crew_member`
+    ADD COLUMN meeting_viewed TINYINT(1) NOT NULL;

--- a/orury-domain/src/test/java/org/orury/domain/config/InfrastructureTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/config/InfrastructureTest.java
@@ -193,7 +193,7 @@ public abstract class InfrastructureTest {
         gymReader = new GymReaderImpl(gymRepository, gymLikeRepository);
         gymStore = new GymStoreImpl(gymRepository, gymLikeRepository);
         //meeting
-        meetingReader = new MeetingReaderImpl(meetingRepository);
+        meetingReader = new MeetingReaderImpl(meetingRepository, meetingMemberRepository, crewMemberRepository);
         meetingStore = new MeetingStoreImpl(meetingRepository);
         meetingMemberReader = new MeetingMemberReaderImpl(meetingMemberRepository, userRepository);
         meetingMemberStore = new MeetingMemberStoreImpl(meetingMemberRepository, meetingRepository);

--- a/orury-domain/src/test/java/org/orury/domain/meeting/infrastructure/MeetingMemberStoreImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/meeting/infrastructure/MeetingMemberStoreImplTest.java
@@ -62,16 +62,15 @@ class MeetingMemberStoreImplTest {
     @Test
     void removeMember() {
         // given
-        MeetingMember meetingMember = mock(MeetingMember.class);
-        given(meetingMember.getMeetingMemberPK())
-                .willReturn(mock(MeetingMemberPK.class));
+        MeetingMember meetingMember = createMeetingMember().build().get();
+        ;
 
         // when
-        meetingMemberStore.removeMember(meetingMember);
+        meetingMemberStore.removeMember(meetingMember.getMeetingMemberPK().getUserId(), meetingMember.getMeetingMemberPK().getMeetingId());
 
         // then
         then(meetingMemberRepository).should(only())
-                .delete(any());
+                .deleteByMeetingMemberPK_UserIdAndMeetingMemberPK_MeetingId(anyLong(), anyLong());
         then(meetingRepository).should(only())
                 .decreaseMemberCount(anyLong());
     }

--- a/orury-domain/src/test/java/org/orury/domain/meeting/infrastructure/MeetingReaderImplTest.java
+++ b/orury-domain/src/test/java/org/orury/domain/meeting/infrastructure/MeetingReaderImplTest.java
@@ -1,12 +1,11 @@
 package org.orury.domain.meeting.infrastructure;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.orury.domain.config.InfrastructureTest;
 import org.orury.domain.crew.domain.entity.Crew;
-import org.orury.domain.meeting.domain.MeetingReader;
 import org.orury.domain.meeting.domain.entity.Meeting;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -21,16 +20,7 @@ import static org.mockito.Mockito.only;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[Reader] 일정 ReaderImpl 테스트")
 @ActiveProfiles("test")
-class MeetingReaderImplTest {
-    MeetingReader meetingReader;
-    MeetingRepository meetingRepository;
-
-    @BeforeEach
-    void setUp() {
-        meetingRepository = mock(MeetingRepository.class);
-
-        meetingReader = new MeetingReaderImpl(meetingRepository);
-    }
+class MeetingReaderImplTest extends InfrastructureTest {
 
     @DisplayName("일정id를 받아, 일정을 조회한다.")
     @Test

--- a/orury-domain/src/testFixtures/java/org/orury/domain/CrewDomainFixture.java
+++ b/orury-domain/src/testFixtures/java/org/orury/domain/CrewDomainFixture.java
@@ -114,6 +114,7 @@ public class CrewDomainFixture {
     @Builder
     public static class TestCrewMember {
         private @Builder.Default CrewMemberPK crewMemberPK = TestCrewMemberPK.createCrewMemberPK().build().get();
+        private @Builder.Default Boolean meetingViewed = true;
         private @Builder.Default LocalDateTime createdAt = LocalDateTime.now();
         private @Builder.Default LocalDateTime updatedAt = LocalDateTime.now();
 


### PR DESCRIPTION
## 개요
### db : 크루모임 조회정보 저장용 필드(meeting_viewed) 추가
- 피그마에 기획된 바에 따르면, 크루별로 마이페이지에서의 일정 조회 여부를 달리하기에, 해당 여부를 DB에 
crew_member 테이블에 meeting_viewed의 Boolean 필드로 추가해놨습니다.
### feat : 다가오는 크루일정 "조회" 구현
- MeetingReaderImpl의 getUpcomingMeetingsByUserId(Long userId) 로직
  1. user의 크루 중에서 meetingViewed가 True로 설정돼있는 크루들 조회
  2. 크루id로 변환
  3. 해당 크루들에서 시작시간이 현재시간 이후인(다가오는) 크루일정들 조회
  4. 로그인된 user가 meetingMember로 속해있는 크루일정들만 남도록 필터링
  5. 반환할 List<Meeting>에 모두 저장
- 최종 반환에서 페이지네이션을 사용하지 않은 이유는, 기획안에서 달력으로 표시될 거라, 한번에 전달하는 방식으로 구현했습니다.
### feat : 다가오는 크루일정 "세팅 조회 및 수정" 구현
- 아래 기획안에서 우측화면을 보시면, 크루별로 크루일정 조회여부를 조회하고 수정할 수 있어야 하기에, 그에 따른 구현입니다.
- 특이사항은 없습니다!
<img width="551" alt="image" src="https://github.com/Kernel360/f1-Orury-Backend/assets/147565215/2dc1bcc1-58ff-4b88-8589-a49b00b71ee3">

 
- 작업사항 중에 변수나 필드명의 경우는 제 선호대로 설정했기에, 피드백 주시면 적극반영하도록 하겠습니다!

closed #446

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
